### PR TITLE
feat: add initial setup wizard for first-run admin

### DIFF
--- a/app/Http/Controllers/Auth/SetupController.php
+++ b/app/Http/Controllers/Auth/SetupController.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Contracts\View\View;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Validation\ValidationException;
@@ -63,6 +64,16 @@ class SetupController extends Controller
             'name_last' => ['nullable', 'string', 'between:0,191'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
+
+        // The cross-process lock below only serializes on an atomic cache driver
+        // (redis/memcached/database/dynamodb). Refuse to run on a non-atomic driver
+        // (e.g. array/file) rather than silently degrading the race protection.
+        if (!in_array(config('cache.default'), ['redis', 'memcached', 'database', 'dynamodb'], true)) {
+            Log::critical('Setup endpoint invoked with a non-atomic cache driver.', [
+                'driver' => config('cache.default'),
+            ]);
+            abort(500, 'The setup flow requires an atomic cache driver.');
+        }
 
         // Serialize creation across concurrent requests. Two near-simultaneous
         // POSTs while the table is empty could otherwise both pass the exists()

--- a/app/Http/Controllers/Auth/SetupController.php
+++ b/app/Http/Controllers/Auth/SetupController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Pterodactyl\Http\Controllers\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Container\Container;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Validation\ValidationException;
+use Pterodactyl\Facades\Activity;
+use Pterodactyl\Models\User;
+use Pterodactyl\Rules\Username;
+use Pterodactyl\Events\Auth\DirectLogin;
+use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Services\Users\UserCreationService;
+
+class SetupController extends Controller
+{
+    protected AuthManager $auth;
+
+    /**
+     * SetupController constructor.
+     */
+    public function __construct(
+        private ViewFactory $view,
+        private UserCreationService $creationService,
+    ) {
+        $this->auth = Container::getInstance()->make(AuthManager::class);
+    }
+
+    /**
+     * Render the SPA shell and let React take over for the guided setup flow.
+     */
+    public function index(): View
+    {
+        return $this->view->make('templates/auth.core');
+    }
+
+    /**
+     * Create the first administrator account and sign the user in.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     * @throws \Pterodactyl\Exceptions\Model\DataValidationException
+     * @throws \Exception
+     */
+    public function store(Request $request): JsonResponse
+    {
+        // Defense in depth: the SetupRequired middleware already blocks this route
+        // once any user exists, but we re-check here so the handler can never be
+        // tricked into creating a second account.
+        if (User::query()->exists()) {
+            abort(404);
+        }
+
+        $data = $this->validate($request, [
+            'email' => ['required', 'string', 'email:rfc', 'between:1,191', 'unique:users,email'],
+            'username' => ['required', 'string', 'between:1,191', 'unique:users,username', new Username()],
+            'name_first' => ['required', 'string', 'between:1,191'],
+            'name_last' => ['nullable', 'string', 'between:0,191'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        // Serialize creation across concurrent requests. Two near-simultaneous
+        // POSTs while the table is empty could otherwise both pass the exists()
+        // check above and create distinct administrator accounts. This cross-
+        // process lock guarantees only one request enters the create block; the
+        // re-check inside it then 404s the loser. Requires an atomic cache driver
+        // (Redis, the panel default) to serialize across workers.
+        $lock = Cache::lock('pterodactyl:setup', 30);
+
+        try {
+            $lock->block(10);
+
+            if (User::query()->exists()) {
+                abort(404);
+            }
+
+            /** @var User $user */
+            $user = $this->creationService->handle([
+                'email' => $data['email'],
+                'username' => $data['username'],
+                'name_first' => $data['name_first'],
+                'name_last' => $data['name_last'] ?? null,
+                'password' => $data['password'],
+                'root_admin' => true,
+            ]);
+        } finally {
+            $lock->release();
+        }
+
+        $request->session()->regenerate();
+        $this->auth->guard()->login($user, true);
+        Event::dispatch(new DirectLogin($user, true));
+
+        Activity::event('setup:admin-created')
+            ->withRequestMetadata()
+            ->subject($user)
+            ->log('created the first administrator account via the web setup flow');
+
+        return new JsonResponse([
+            'data' => [
+                'complete' => true,
+                'intended' => '/',
+            ],
+        ]);
+    }
+}

--- a/app/Http/Middleware/SetupRequired.php
+++ b/app/Http/Middleware/SetupRequired.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pterodactyl\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Pterodactyl\Models\User;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Gates the first-run setup routes.
+ *
+ * The setup flow is the only unauthenticated endpoint capable of creating an
+ * account with administrator privileges. Once any user has been created on the
+ * system — administrator or not — this middleware hard-fails every setup route
+ * with a 404, so the surface simply disappears once installation is complete.
+ */
+class SetupRequired
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (User::query()->exists()) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Pterodactyl\Http\Middleware\TrimStrings;
 use Pterodactyl\Http\Middleware\AdminAuthenticate;
 use Pterodactyl\Http\Middleware\RequireTwoFactorAuthentication;
+use Pterodactyl\Http\Middleware\SetupRequired;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class RouteServiceProvider extends ServiceProvider
@@ -45,6 +46,11 @@ class RouteServiceProvider extends ServiceProvider
                     ->group(base_path('routes/admin.php'));
 
                 Route::middleware('guest')->prefix('/auth')->group(base_path('routes/auth.php'));
+
+                // First-run setup. SetupRequired 404s every route here once a user
+                // exists, so the surface closes itself off after the initial install.
+                Route::middleware(['throttle:authentication', SetupRequired::class])
+                    ->group(base_path('routes/setup.php'));
             });
 
             Route::middleware(['api', RequireTwoFactorAuthentication::class])->group(function () {

--- a/resources/scripts/api/auth/setup.ts
+++ b/resources/scripts/api/auth/setup.ts
@@ -1,0 +1,32 @@
+import http from '@/api/http';
+
+export interface SetupData {
+    email: string;
+    username: string;
+    name_first: string;
+    name_last?: string;
+    password: string;
+    password_confirmation: string;
+}
+
+export interface SetupResponse {
+    complete: boolean;
+    intended?: string;
+}
+
+/**
+ * Create the first administrator account through the first-run setup flow.
+ * Mirrors the login call: prime the CSRF cookie, then POST to /setup. The
+ * backend creates the account, grants admin, and starts the session — so on
+ * success the response carries an `intended` path to hard-navigate to.
+ */
+export default async (data: SetupData): Promise<SetupResponse> => {
+    await http.get('/sanctum/csrf-cookie');
+
+    const response = await http.post('/setup', data);
+
+    return {
+        complete: response.data?.data?.complete ?? response.data?.complete ?? false,
+        intended: response.data?.data?.intended ?? response.data?.intended ?? '/',
+    };
+};

--- a/resources/scripts/components/App.tsx
+++ b/resources/scripts/components/App.tsx
@@ -24,9 +24,11 @@ import HydrodactylProvider from './HydrodactylProvider';
 // const ServerRouter = lazy(() => import('@/routers/ServerRouter'));
 const UnifiedRouter = lazy(() => import('@/routers/UnifiedRouter'));
 const AuthenticationRouter = lazy(() => import('@/routers/AuthenticationRouter'));
+const SetupRouter = lazy(() => import('@/routers/SetupRouter'));
 
 interface ExtendedWindow extends Window {
     SiteConfiguration?: SiteSettings;
+    SetupRequired?: boolean;
     PyrodactylUser?: {
         uuid: string;
         username: string;
@@ -79,6 +81,14 @@ const App = () => {
                         />
                         <BrowserRouter>
                             <Routes>
+                                <Route
+                                    path='/setup/*'
+                                    element={
+                                        <Spinner.Suspense>
+                                            <SetupRouter />
+                                        </Spinner.Suspense>
+                                    }
+                                />
                                 <Route
                                     path='/auth/*'
                                     element={

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -125,7 +125,7 @@ function LoginContainer() {
 
                     <div className='flex w-full justify-between items-center'>
                         <Button
-                            className={`bg-mocha-100 rounded-full p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 hover:scale-102 ease-in-out`}
+                            className={`bg-mocha-100 rounded-lg p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 ease-in-out`}
                             type={'submit'}
                             size={'xlarge'}
                             isLoading={isSubmitting}

--- a/resources/scripts/components/elements/AuthenticatedRoute.tsx
+++ b/resources/scripts/components/elements/AuthenticatedRoute.tsx
@@ -12,6 +12,12 @@ function AuthenticatedRoute({ children }: { children?: ReactNode }): JSX.Element
         return <>{children}</>;
     }
 
+    // Fresh install with no users yet — guide the visitor to first-run setup
+    // instead of the (empty) login page.
+    if ((window as { SetupRequired?: boolean }).SetupRequired) {
+        return <Navigate to='/setup' replace />;
+    }
+
     return <Navigate to='/auth/login' state={{ from: location.pathname }} />;
 }
 

--- a/resources/scripts/components/setup/SetupContainer.tsx
+++ b/resources/scripts/components/setup/SetupContainer.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { object, string } from 'yup';
 
 import setupAdmin from '@/api/auth/setup';
-import Button from '@/components/elements/Button';
+import { Button } from '@/components/ui/button';
 import Field from '@/components/elements/Field';
 import FlashMessageRender from '@/components/FlashMessageRender';
 import { cn } from '@/lib/utils';
@@ -56,7 +56,7 @@ const schema = object().shape({
     password: string().required('A password is required.').min(8, 'Use at least 8 characters.'),
     password_confirmation: string()
         .required('Please confirm your password.')
-        .test('password-match', 'Passwords do not match.', function (v) {
+        .test('password-match', 'Passwords do not match.', function(v) {
             // Let .required() own the empty case so only one message shows.
             if (!v) return true;
             return v === this.parent.password;
@@ -334,6 +334,7 @@ const SetupContainer = () => {
                                 {step > 0 ? (
                                     <Button
                                         type='button'
+                                        variant='secondary'
                                         onClick={back}
                                         disabled={isSubmitting}
                                         className='text-secondary hover:text-cream-200 rounded-lg px-4 py-2.5 text-sm transition-colors disabled:opacity-40'
@@ -347,14 +348,9 @@ const SetupContainer = () => {
                                     <Button
                                         key='advance'
                                         type='button'
+                                        variant='attention'
                                         onClick={advance}
                                         disabled={isSubmitting}
-                                        className={cn(
-                                            'rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50',
-                                            ready
-                                                ? 'bg-brand hover:bg-brand-600 text-white shadow-[0_0_24px_-4px_rgba(250,78,73,0.55)] hover:shadow-[0_0_30px_-2px_rgba(250,78,73,0.7)]'
-                                                : 'bg-mocha-100 hover:bg-mocha-200 text-black',
-                                        )}
                                     >
                                         {step === 0 ? 'Get started' : 'Continue'}
                                     </Button>
@@ -362,15 +358,10 @@ const SetupContainer = () => {
                                     <Button
                                         key='submit'
                                         type='button'
+                                        variant='attention'
                                         onClick={handleSubmit}
                                         isLoading={isSubmitting}
                                         disabled={isSubmitting}
-                                        className={cn(
-                                            'rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50',
-                                            ready
-                                                ? 'bg-brand hover:bg-brand-600 text-white shadow-[0_0_24px_-4px_rgba(250,78,73,0.55)] hover:shadow-[0_0_30px_-2px_rgba(250,78,73,0.7)]'
-                                                : 'bg-mocha-100 hover:bg-mocha-200 text-black',
-                                        )}
                                     >
                                         Create admin account
                                     </Button>

--- a/resources/scripts/components/setup/SetupContainer.tsx
+++ b/resources/scripts/components/setup/SetupContainer.tsx
@@ -224,7 +224,7 @@ const SetupContainer = () => {
 
     return (
         <Formik initialValues={INITIAL} validationSchema={schema} onSubmit={onSubmit} validateOnBlur validateOnChange={false}>
-            {({ values, validateForm, setTouched, isSubmitting }) => {
+            {({ values, validateForm, setTouched, isSubmitting, handleSubmit }) => {
                 // validateForm() runs the full schema and is what populates the
                 // Formik `errors` the touched <Field>s render against — keep it.
                 const advance = async () => {
@@ -244,6 +244,9 @@ const SetupContainer = () => {
                 };
 
                 const back = () => setStep((s) => Math.max(0, s - 1));
+
+                // Light up the primary CTA once the current step is ready to proceed.
+                const ready = step === 0 ? true : schema.isValidSync(values);
 
                 return (
                     <Form className='w-full max-w-md mx-auto flex flex-col gap-8'>
@@ -342,19 +345,32 @@ const SetupContainer = () => {
                                 )}
                                 {step < STEP_LABELS.length - 1 ? (
                                     <Button
+                                        key='advance'
                                         type='button'
                                         onClick={advance}
                                         disabled={isSubmitting}
-                                        className='bg-mocha-100 hover:bg-mocha-200 text-black rounded-lg px-5 py-2.5 text-sm font-medium transition-colors disabled:opacity-50'
+                                        className={cn(
+                                            'rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50',
+                                            ready
+                                                ? 'bg-brand hover:bg-brand-600 text-white shadow-[0_0_24px_-4px_rgba(250,78,73,0.55)] hover:shadow-[0_0_30px_-2px_rgba(250,78,73,0.7)]'
+                                                : 'bg-mocha-100 hover:bg-mocha-200 text-black',
+                                        )}
                                     >
                                         {step === 0 ? 'Get started' : 'Continue'}
                                     </Button>
                                 ) : (
                                     <Button
-                                        type='submit'
+                                        key='submit'
+                                        type='button'
+                                        onClick={handleSubmit}
                                         isLoading={isSubmitting}
                                         disabled={isSubmitting}
-                                        className='bg-brand hover:bg-brand-600 text-white rounded-lg px-5 py-2.5 text-sm font-medium transition-colors disabled:opacity-50'
+                                        className={cn(
+                                            'rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50',
+                                            ready
+                                                ? 'bg-brand hover:bg-brand-600 text-white shadow-[0_0_24px_-4px_rgba(250,78,73,0.55)] hover:shadow-[0_0_30px_-2px_rgba(250,78,73,0.7)]'
+                                                : 'bg-mocha-100 hover:bg-mocha-200 text-black',
+                                        )}
                                     >
                                         Create admin account
                                     </Button>

--- a/resources/scripts/components/setup/SetupContainer.tsx
+++ b/resources/scripts/components/setup/SetupContainer.tsx
@@ -1,0 +1,371 @@
+import { Formik, Form, type FormikHelpers } from 'formik';
+import { useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { object, string } from 'yup';
+
+import setupAdmin from '@/api/auth/setup';
+import Button from '@/components/elements/Button';
+import Field from '@/components/elements/Field';
+import FlashMessageRender from '@/components/FlashMessageRender';
+import { cn } from '@/lib/utils';
+import useFlash from '@/plugins/useFlash';
+
+interface Values {
+    email: string;
+    username: string;
+    name_first: string;
+    name_last: string;
+    password: string;
+    password_confirmation: string;
+}
+
+const INITIAL: Values = {
+    email: '',
+    username: '',
+    name_first: '',
+    name_last: '',
+    password: '',
+    password_confirmation: '',
+};
+
+const STEP_LABELS = ['Welcome', 'Admin account', 'Review'] as const;
+
+// Fields that must be valid before leaving each step. The welcome and review
+// steps have nothing to validate — they advance unconditionally.
+const STEP_FIELDS: Record<number, (keyof Values)[]> = {
+    1: ['email', 'username', 'name_first', 'password', 'password_confirmation'],
+};
+
+// Mirrors the backend Username rule (lowercased before testing). The regex
+// implies a minimum length of 3: a leading char, at least one middle char, and
+// a trailing char — so the frontend enforces the same floor the backend does.
+const USERNAME_RE = /^[a-z0-9]([\w.-]+)[a-z0-9]$/;
+
+const schema = object().shape({
+    email: string().required('An email is required.').email('Enter a valid email address.').max(191),
+    username: string()
+        .required('A username is required.')
+        .max(191)
+        .test(
+            'username-format',
+            'Use 3-191 characters, starting and ending with a letter or number. Only letters, numbers, dots, dashes, and underscores are allowed.',
+            (v) => !v || (v.length >= 3 && USERNAME_RE.test(v.toLowerCase())),
+        ),
+    name_first: string().required('A first name is required.').max(191),
+    name_last: string().max(191).nullable(),
+    password: string().required('A password is required.').min(8, 'Use at least 8 characters.'),
+    password_confirmation: string()
+        .required('Please confirm your password.')
+        .test('password-match', 'Passwords do not match.', function (v) {
+            // Let .required() own the empty case so only one message shows.
+            if (!v) return true;
+            return v === this.parent.password;
+        }),
+});
+
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+function scorePassword(pw: string): number {
+    if (!pw) return 0;
+    let score = 0;
+    if (pw.length >= 8) score++;
+    if (pw.length >= 12) score++;
+    if (/[a-z]/.test(pw) && /[A-Z]/.test(pw)) score++;
+    if (/\d/.test(pw)) score++;
+    if (/[^A-Za-z0-9]/.test(pw)) score++;
+    return Math.min(4, Math.max(0, score));
+}
+
+const STRENGTH = [
+    { label: 'Too short', className: 'bg-[#d36666]' },
+    { label: 'Weak', className: 'bg-[#d36666]' },
+    { label: 'Fair', className: 'bg-mocha-50' },
+    { label: 'Good', className: 'bg-brand-400' },
+    { label: 'Strong', className: 'bg-brand-500' },
+];
+
+const PasswordStrength = ({ value }: { value: string }) => {
+    if (!value) return null;
+    const score = scorePassword(value);
+    // scorePassword() always returns 0-4 and STRENGTH has one entry per value.
+    const { label, className } = STRENGTH[score]!;
+
+    return (
+        <div className='flex items-center gap-3 mt-2.5'>
+            <div className='flex gap-1 flex-1'>
+                {[0, 1, 2, 3].map((i) => (
+                    <div
+                        key={i}
+                        className={cn(
+                            'h-1 flex-1 rounded-full transition-colors duration-200',
+                            i < score ? className : 'bg-white/8',
+                        )}
+                    />
+                ))}
+            </div>
+            <span className='text-xs text-secondary tabular-nums w-14 text-right'>{label}</span>
+        </div>
+    );
+};
+
+const StepTracker = ({ current }: { current: number }) => (
+    <div className='flex items-center gap-3'>
+        {STEP_LABELS.map((label, i) => {
+            const state = i < current ? 'done' : i === current ? 'active' : 'upcoming';
+            return (
+                <div key={label} className='flex items-center gap-2'>
+                    <div
+                        className={cn(
+                            'h-1.5 w-8 rounded-full transition-colors duration-200',
+                            state === 'active' && 'bg-brand-500',
+                            state === 'done' && 'bg-brand-500/40',
+                            state === 'upcoming' && 'bg-white/8',
+                        )}
+                    />
+                    <span
+                        className={cn(
+                            'text-xs transition-colors duration-200 hidden sm:inline',
+                            state === 'active' ? 'text-cream-200' : 'text-secondary',
+                        )}
+                    >
+                        {label}
+                    </span>
+                </div>
+            );
+        })}
+    </div>
+);
+
+const ReviewRow = ({ label, value }: { label: string; value: string }) => (
+    <div className='flex items-center justify-between gap-4 py-2.5'>
+        <dt className='text-sm text-secondary'>{label}</dt>
+        <dd className='text-sm text-cream-200 text-right truncate'>{value || '—'}</dd>
+    </div>
+);
+
+const SuccessPanel = ({ email }: { email: string }) => (
+    <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.25 }}
+        className='flex flex-col items-center text-center py-6 gap-4'
+    >
+        <svg width='44' height='44' viewBox='0 0 44 44' fill='none' xmlns='http://www.w3.org/2000/svg'>
+            <circle cx='22' cy='22' r='21' stroke='#fa4e49' strokeWidth='2' opacity='0.35' />
+            <motion.path
+                d='M14 22.5L19.5 28L31 16'
+                stroke='#fa4e49'
+                strokeWidth='2.5'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                initial={{ pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={{ duration: 0.4, ease: EASE, delay: 0.1 }}
+            />
+        </svg>
+        <div className='space-y-1.5'>
+            <h2 className='text-2xl font-semibold text-cream-200'>You&apos;re all set</h2>
+            <p className='text-sm text-secondary'>Signed in as {email}. Taking you to your dashboard…</p>
+        </div>
+        {/* Fallback in case the auto-redirect below is interrupted (e.g. the tab
+            is refreshed during the brief delay). The session is already valid. */}
+        <a
+            href='/'
+            className='text-sm text-secondary underline decoration-white/20 underline-offset-4 hover:text-cream-200 transition-colors'
+        >
+            Open dashboard
+        </a>
+    </motion.div>
+);
+
+const SetupContainer = () => {
+    const { clearFlashes, clearAndAddHttpError } = useFlash();
+    const prefersReducedMotion = useReducedMotion();
+    const [step, setStep] = useState(0);
+    const [done, setDone] = useState(false);
+
+    const stepMotion = {
+        initial: prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 10 },
+        animate: prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
+        exit: prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -10 },
+        transition: { duration: 0.24, ease: EASE },
+    };
+
+    const onSubmit = async (values: Values, { setSubmitting }: FormikHelpers<Values>) => {
+        clearFlashes();
+        // Final guard before the network: re-validate the full schema. If a field
+        // went stale after the user stepped forward, send them back to fix it.
+        try {
+            await schema.validate(values, { abortEarly: false });
+        } catch {
+            setSubmitting(false);
+            setStep(1);
+            return;
+        }
+
+        try {
+            const res = await setupAdmin({
+                ...values,
+                name_last: values.name_last || undefined,
+            });
+            if (res.complete) {
+                setDone(true);
+                window.setTimeout(() => {
+                    window.location.href = res.intended || '/';
+                }, 800);
+            } else {
+                setSubmitting(false);
+            }
+        } catch (error) {
+            clearAndAddHttpError({ error });
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Formik initialValues={INITIAL} validationSchema={schema} onSubmit={onSubmit} validateOnBlur validateOnChange={false}>
+            {({ values, validateForm, setTouched, isSubmitting }) => {
+                // validateForm() runs the full schema and is what populates the
+                // Formik `errors` the touched <Field>s render against — keep it.
+                const advance = async () => {
+                    const all = await validateForm(values);
+                    const fields = STEP_FIELDS[step] ?? [];
+                    if (fields.length) {
+                        const touch = {} as { [K in keyof Values]?: boolean };
+                        let blocked = false;
+                        for (const f of fields) {
+                            touch[f] = true;
+                            if (all[f]) blocked = true;
+                        }
+                        setTouched(touch);
+                        if (blocked) return;
+                    }
+                    setStep((s) => Math.min(s + 1, STEP_LABELS.length - 1));
+                };
+
+                const back = () => setStep((s) => Math.max(0, s - 1));
+
+                return (
+                    <Form className='w-full max-w-md mx-auto flex flex-col gap-8'>
+                        <FlashMessageRender />
+
+                        {!done && <StepTracker current={step} />}
+
+                        <AnimatePresence mode='wait' initial={false}>
+                            {done ? (
+                                <motion.div key='done' {...stepMotion}>
+                                    <SuccessPanel email={values.email} />
+                                </motion.div>
+                            ) : step === 0 ? (
+                                <motion.div key='welcome' {...stepMotion} className='space-y-5'>
+                                    <div className='space-y-3'>
+                                        <h2 className='text-3xl font-semibold text-cream-200 tracking-tight'>
+                                            Welcome.
+                                        </h2>
+                                        <p className='text-sm text-secondary leading-relaxed'>
+                                            This is a fresh Hydrodactyl installation — no administrator account exists
+                                            yet. We&apos;ll create your first account, grant it full panel access, and
+                                            sign you right in. It only takes a moment.
+                                        </p>
+                                    </div>
+                                    <p className='text-xs text-secondary leading-relaxed border-t border-white/10 pt-4'>
+                                        You won&apos;t see this again. Once an account exists, this setup screen
+                                        disappears entirely.
+                                    </p>
+                                </motion.div>
+                            ) : step === 1 ? (
+                                <motion.div key='account' {...stepMotion} className='space-y-5'>
+                                    <div className='space-y-1'>
+                                        <h2 className='text-2xl font-semibold text-cream-200 tracking-tight'>
+                                            Create your account
+                                        </h2>
+                                        <p className='text-sm text-secondary'>
+                                            These are your administrator credentials.
+                                        </p>
+                                    </div>
+                                    <Field id='email' name='email' type='email' label='Email' disabled={isSubmitting} />
+                                    <Field id='username' name='username' type='text' label='Username' disabled={isSubmitting} />
+                                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
+                                        <Field id='name_first' name='name_first' type='text' label='First name' disabled={isSubmitting} />
+                                        <Field id='name_last' name='name_last' type='text' label='Last name' disabled={isSubmitting} />
+                                    </div>
+                                    <div>
+                                        <Field id='password' name='password' type='password' label='Password' disabled={isSubmitting} />
+                                        <PasswordStrength value={values.password} />
+                                    </div>
+                                    <Field
+                                        id='password_confirmation'
+                                        name='password_confirmation'
+                                        type='password'
+                                        label='Confirm password'
+                                        disabled={isSubmitting}
+                                    />
+                                </motion.div>
+                            ) : (
+                                <motion.div key='review' {...stepMotion} className='space-y-5'>
+                                    <div className='space-y-1'>
+                                        <h2 className='text-2xl font-semibold text-cream-200 tracking-tight'>
+                                            Review &amp; create
+                                        </h2>
+                                        <p className='text-sm text-secondary'>Make sure everything looks right.</p>
+                                    </div>
+                                    <dl className='divide-y divide-white/10'>
+                                        <ReviewRow label='Email' value={values.email} />
+                                        <ReviewRow label='Username' value={values.username} />
+                                        <ReviewRow
+                                            label='Name'
+                                            value={[values.name_first, values.name_last].filter(Boolean).join(' ')}
+                                        />
+                                        <ReviewRow label='Role' value='Administrator' />
+                                    </dl>
+                                    <p className='text-xs text-secondary leading-relaxed'>
+                                        This account will be created with full administrator privileges, then
+                                        you&apos;ll be signed in immediately.
+                                    </p>
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+
+                        {!done && (
+                            <div className='flex items-center justify-between gap-3'>
+                                {step > 0 ? (
+                                    <Button
+                                        type='button'
+                                        onClick={back}
+                                        disabled={isSubmitting}
+                                        className='text-secondary hover:text-cream-200 rounded-lg px-4 py-2.5 text-sm transition-colors disabled:opacity-40'
+                                    >
+                                        Back
+                                    </Button>
+                                ) : (
+                                    <span />
+                                )}
+                                {step < STEP_LABELS.length - 1 ? (
+                                    <Button
+                                        type='button'
+                                        onClick={advance}
+                                        disabled={isSubmitting}
+                                        className='bg-mocha-100 hover:bg-mocha-200 text-black rounded-lg px-5 py-2.5 text-sm font-medium transition-colors disabled:opacity-50'
+                                    >
+                                        {step === 0 ? 'Get started' : 'Continue'}
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        type='submit'
+                                        isLoading={isSubmitting}
+                                        disabled={isSubmitting}
+                                        className='bg-brand hover:bg-brand-600 text-white rounded-lg px-5 py-2.5 text-sm font-medium transition-colors disabled:opacity-50'
+                                    >
+                                        Create admin account
+                                    </Button>
+                                )}
+                            </div>
+                        )}
+                    </Form>
+                );
+            }}
+        </Formik>
+    );
+};
+
+export default SetupContainer;

--- a/resources/scripts/routers/SetupRouter.tsx
+++ b/resources/scripts/routers/SetupRouter.tsx
@@ -1,0 +1,63 @@
+import { Navigate } from 'react-router-dom';
+
+import SetupContainer from '@/components/setup/SetupContainer';
+import Logo from '@/components/elements/HydroLogo';
+
+// `window.SetupRequired` is injected by the backend (templates/wrapper.blade.php)
+// only when the panel is unauthenticated and has zero users. Once any user
+// exists the flag is absent and `/setup` bounces back to the app root.
+const setupRequired = () => !!(window as { SetupRequired?: boolean }).SetupRequired;
+
+const SetupRouter = () => {
+    if (!setupRequired()) {
+        return <Navigate to='/' replace />;
+    }
+
+    return (
+        <div className='absolute w-full h-full flex justify-center items-center rounded-md [--page-padding:--spacing(8)]'>
+            {/* Noise texture — shared with the auth surface for continuity. */}
+            <div
+                style={{
+                    backgroundImage: 'url(/assets/auth-noise.png)',
+                    backgroundSize: '1920px 1080px',
+                    backgroundRepeat: 'repeat',
+                    backgroundPosition: '0 0',
+                }}
+                className='pointer-events-none fixed inset-0 z-1 opacity-[0.4]'
+            />
+            <div className='flex size-full'>
+                <div className='w-full max-w-4xl z-2 flex items-center bg-bg-lowered px-[calc(var(--page-padding)*3)] py-[calc(var(--page-padding)*2)] overflow-y-auto'>
+                    <SetupContainer />
+                </div>
+
+                {/* Brand panel */}
+                <div className='w-full relative hidden md:block'>
+                    <div className='flex items-center gap-3 h-6 absolute right-(--page-padding) top-(--page-padding) text-lg text-cream-300'>
+                        <Logo className='h-full w-auto' />
+                        <div className='border-l border-cream-300/20 h-full' />
+                        <span className='text-sm tracking-wide'>Hydrodactyl</span>
+                    </div>
+
+                    <div className='absolute inset-0 flex flex-col justify-end p-(--page-padding) gap-3'>
+                        <h1 className='text-4xl font-semibold text-cream-200 text-wrap-pretty max-w-sm leading-tight'>
+                            Set up your panel.
+                        </h1>
+                        <p className='text-sm text-secondary max-w-sm leading-relaxed'>
+                            A fresh install has no administrator yet — let&apos;s create your first
+                            account and get you signed in.
+                        </p>
+                    </div>
+
+                    {/* Gradients — same family as the auth surface. */}
+                    <div className='opacity-50'>
+                        <div className='absolute inset-0 bg-gradient-to-tr from-transparent via-brand-400/5 to-brand-600/10' />
+                        <div className='absolute inset-0 bg-gradient-to-tr to-transparent via-brand-400/5 from-brand-600/10' />
+                        <div className='absolute top-0 left-0 w-full h-32 bg-gradient-to-b from-brand-500/13 to-transparent' />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SetupRouter;

--- a/resources/scripts/routers/SetupRouter.tsx
+++ b/resources/scripts/routers/SetupRouter.tsx
@@ -26,7 +26,7 @@ const SetupRouter = () => {
                 className='pointer-events-none fixed inset-0 z-1 opacity-[0.4]'
             />
             <div className='flex size-full'>
-                <div className='w-full max-w-4xl z-2 flex items-center bg-bg-lowered px-[calc(var(--page-padding)*3)] py-[calc(var(--page-padding)*2)] overflow-y-auto'>
+                <div className='w-full max-w-4xl z-2 flex items-start sm:items-center bg-bg-lowered px-5 py-8 sm:px-[calc(var(--page-padding)*3)] sm:py-[calc(var(--page-padding)*2)] overflow-y-auto'>
                     <SetupContainer />
                 </div>
 

--- a/resources/views/templates/wrapper.blade.php
+++ b/resources/views/templates/wrapper.blade.php
@@ -33,6 +33,9 @@
                     window.SiteConfiguration = {!! json_encode($siteConfiguration) !!};
                 </script>
             @endif
+            @if(Auth::guest() && !\Pterodactyl\Models\User::query()->exists())
+                <script>window.SetupRequired = true;</script>
+            @endif
         @show
         <style>
             @import url('https://fonts.bunny.net/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap')

--- a/routes/base.php
+++ b/routes/base.php
@@ -14,4 +14,4 @@ Route::get('/locales/locale.json', Base\LocaleController::class)
   ->where('namespace', '.*');
 
 Route::get('/{react}', [Base\IndexController::class, 'index'])
-  ->where('react', '^(?!(\/)?(api|auth|admin|daemon)).+');
+  ->where('react', '^(?!(\/)?(api|auth|admin|daemon|setup)).+');

--- a/routes/setup.php
+++ b/routes/setup.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Pterodactyl\Http\Controllers\Auth\SetupController;
+use Pterodactyl\Http\Middleware\SetupRequired;
+
+/*
+|--------------------------------------------------------------------------
+| First-run setup routes
+|--------------------------------------------------------------------------
+|
+| Endpoint: /setup
+|
+| These routes only exist while the panel has zero users. The SetupRequired
+| middleware returns a 404 for every request here the moment a single user
+| has been created, so the surface closes itself off permanently once the
+| initial administrator exists.
+|
+*/
+
+Route::middleware(SetupRequired::class)->group(function () {
+    Route::get('/setup', [SetupController::class, 'index'])->name('setup.index');
+    Route::post('/setup', [SetupController::class, 'store'])->name('setup.store');
+});


### PR DESCRIPTION
## Summary

Implements #10 — a first-run setup flow so a brand-new install can create its first administrator account from the browser, with **no terminal access required**.

When the panel has **zero users**, visiting `/` redirects to a guided `/setup` wizard (Welcome → Admin account → Review → Create) that creates the first admin and signs them in. The surface self-closes (404) the moment any user exists.

## How it works

**Backend**
- `GET/POST /setup` in `routes/setup.php`, gated by a new `SetupRequired` middleware that 404s every setup route once a user exists.
- `SetupController::store` validates input, creates the admin via `UserCreationService` (`root_admin => true`), regenerates the session + logs the user in, and writes an activity log entry (`setup:admin-created`).
- `routes/base.php` excludes `setup` from the `/{react}` catch-all so `/setup` is served by the dedicated route (otherwise the catch-all shadows it).
- `wrapper.blade.php` injects `window.SetupRequired` only while `Auth::guest() && no users exist`.

**Frontend** (React 19 + Formik + motion, reusing the existing auth design system)
- `SetupRouter` — split-panel shell matching the auth surface; responsive (comfortable on mobile, centered split on desktop).
- `SetupContainer` — 3-step wizard with per-step validation, a password-strength meter, a primary CTA that glows when the step is validly filled, and `prefers-reduced-motion` support. All buttons are `type="button"`; the final submit runs through Formik's `handleSubmit`, so the form can't submit until "Create admin account" is explicitly clicked.

## Security model

This is an **unauthenticated endpoint that grants admin**, so it's belt-and-suspenders:

- `SetupRequired` middleware (route) + an in-controller `User::exists()` re-check (defense in depth).
- A cross-process `Cache::lock` + re-check closes the TOCTOU race (two concurrent POSTs can't both create an admin); refuses to run on a non-atomic cache driver (`array`/`file`) rather than silently degrading.
- `root_admin` is set by a controller literal, never from request input; `$fillable` + model validation guard mass-assignment.
- CSRF via the `web` group (`PreventRequestForgery`); session regenerated before login; `throttle:authentication` rate limiting.
- Once any user exists, `/setup` 404s for both GET and POST.

## Testing

- `tsc --noEmit` clean for all new files; `php -l` clean.
- Built and ran the full panel in Docker (MariaDB + Redis) and walked the flow live via browser automation: `/` → `/setup`, per-step validation, the Review step, admin created with `root_admin=1`, auto-login to the dashboard, and `/setup` → 404 post-install.
- Verified mobile (375px) form width and desktop (1280px) layout separately.
- Two independent pre-PR reviews (correctness + security), both **SHIP** (0 Critical / 0 High); the one consensus Medium (the cache-driver guard) is addressed in this PR.

## Files

**New:** `app/Http/Controllers/Auth/SetupController.php`, `app/Http/Middleware/SetupRequired.php`, `routes/setup.php`, `resources/scripts/api/auth/setup.ts`, `resources/scripts/routers/SetupRouter.tsx`, `resources/scripts/components/setup/SetupContainer.tsx`

**Modified:** `app/Providers/RouteServiceProvider.php`, `resources/scripts/components/App.tsx`, `resources/scripts/components/elements/AuthenticatedRoute.tsx`, `resources/scripts/components/auth/LoginContainer.tsx` (button-radius cohesion with the new surface), `resources/views/templates/wrapper.blade.php`, `routes/base.php`

Closes #10.
