### PR TITLE
feat: server sorting, filtering, and search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY . .
 RUN if [ "$DEV" = "false" ]; then \
     CI=true pnpm install --frozen-lockfile \
     && pnpm run ship; \
+    else \
+    mkdir -p public/assets public/build; \
     fi
 
 # Stage 1:
@@ -57,7 +59,11 @@ COPY --from=frontend /app/public/build public/build
 COPY composer.json composer.lock ./
 RUN curl -sS https://getcomposer.org/installer \
     | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-dev --optimize-autoloader
+    && if [ "$DEV" = "false" ]; then \
+    composer install --no-dev --optimize-autoloader; \
+    else \
+    composer install; \
+    fi
 
 # Clean up image for dev environment
 # This is because we share local files with the container

--- a/app/Http/Controllers/Api/Client/ClientController.php
+++ b/app/Http/Controllers/Api/Client/ClientController.php
@@ -78,6 +78,10 @@ class ClientController extends ClientApiController
             }
         } elseif ($type === 'owner') {
             $builder = $builder->where('servers.owner_id', $user->id);
+        } elseif ($type === 'shared') {
+            $builder = $builder->whereIn('servers.id', function ($q) use ($user) {
+                $q->select('server_id')->from('subusers')->where('user_id', $user->id);
+            });
         } elseif ($type === 'all') {
             $builder = $builder->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
         } else {

--- a/app/Http/Controllers/Api/Client/ClientController.php
+++ b/app/Http/Controllers/Api/Client/ClientController.php
@@ -6,20 +6,17 @@ use Pterodactyl\Models\Server;
 use Pterodactyl\Models\Permission;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedSort;
 use Pterodactyl\Models\Filters\MultiFieldServerFilter;
+use Pterodactyl\Models\Sorts\ServerOwnerNameSort;
+use Pterodactyl\Models\Sorts\ServerNestNameSort;
+use Pterodactyl\Models\Sorts\ServerEggNameSort;
+use Pterodactyl\Models\Sorts\ServerNodeNameSort;
 use Pterodactyl\Transformers\Api\Client\ServerTransformer;
 use Pterodactyl\Http\Requests\Api\Client\GetServersRequest;
 
 class ClientController extends ClientApiController
 {
-    /**
-     * ClientController constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
      * Return all the servers available to the client making the API
      * request, including servers the user has access to as a subuser.
@@ -38,7 +35,30 @@ class ClientController extends ClientApiController
             'description',
             'external_id',
             'daemonType',
+            'owner_id',
+            'nest_id',
+            'egg_id',
+            'node_id',
             AllowedFilter::custom('*', new MultiFieldServerFilter()),
+        ])->allowedSorts([
+            'name',
+            'uuid',
+            'uuidShort',
+            'description',
+            'status',
+            'owner_id',
+            'nest_id',
+            'egg_id',
+            'node_id',
+            'memory',
+            'disk',
+            'cpu',
+            'created_at',
+            'updated_at',
+            AllowedSort::custom('owner_name', new ServerOwnerNameSort()),
+            AllowedSort::custom('nest_name', new ServerNestNameSort()),
+            AllowedSort::custom('egg_name', new ServerEggNameSort()),
+            AllowedSort::custom('node_name', new ServerNodeNameSort()),
         ]);
 
         $type = $request->input('type');
@@ -59,7 +79,6 @@ class ClientController extends ClientApiController
         } elseif ($type === 'owner') {
             $builder = $builder->where('servers.owner_id', $user->id);
         } elseif ($type === 'all') {
-            // Yes, I'm well aware this and the one below it are the same function, shut Up, I know. it's not a bug
             $builder = $builder->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
         } else {
             $builder = $builder->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
@@ -68,6 +87,63 @@ class ClientController extends ClientApiController
         $servers = $builder->paginate(min($request->query('per_page', 50), 100))->appends($request->query());
 
         return $this->fractal->transformWith($transformer)->collection($servers)->toArray();
+    }
+
+    /**
+     * Returns distinct filter options (owners, nests, eggs, nodes) for servers
+     * accessible to the current user. Used to populate the category filter dropdown.
+     */
+    public function filterOptions(GetServersRequest $request): array
+    {
+        $user = $request->user();
+
+        $baseQuery = Server::query();
+        if (!$user->root_admin) {
+            $baseQuery->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
+        }
+
+        $owners = (clone $baseQuery)
+            ->leftJoin('users', 'servers.owner_id', '=', 'users.id')
+            ->select('users.id as value', \Illuminate\Support\Facades\DB::raw("CONCAT(users.name_first, ' ', users.name_last) as label"))
+            ->whereNotNull('users.id')
+            ->distinct()
+            ->orderBy('users.name_first')
+            ->orderBy('users.name_last')
+            ->get();
+
+        $nests = (clone $baseQuery)
+            ->leftJoin('nests', 'servers.nest_id', '=', 'nests.id')
+            ->select('nests.id as value', 'nests.name as label')
+            ->whereNotNull('nests.id')
+            ->distinct()
+            ->orderBy('nests.name')
+            ->get();
+
+        $eggs = (clone $baseQuery)
+            ->leftJoin('eggs', 'servers.egg_id', '=', 'eggs.id')
+            ->select('eggs.id as value', 'eggs.name as label')
+            ->whereNotNull('eggs.id')
+            ->distinct()
+            ->orderBy('eggs.name')
+            ->get();
+
+        $nodes = (clone $baseQuery)
+            ->leftJoin('nodes', 'servers.node_id', '=', 'nodes.id')
+            ->select('nodes.id as value', 'nodes.name as label')
+            ->whereNotNull('nodes.id')
+            ->distinct()
+            ->orderBy('nodes.name')
+            ->get();
+
+        return [
+            'object' => 'server_filter_options',
+            'attributes' => [
+                'owners' => $owners,
+                'nests' => $nests,
+                'eggs' => $eggs,
+                'nodes' => $nodes,
+            ],
+        ];
     }
 
     /**

--- a/app/Models/Sorts/ServerEggNameSort.php
+++ b/app/Models/Sorts/ServerEggNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerEggNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('eggs', 'servers.egg_id', '=', 'eggs.id')
+            ->orderBy('eggs.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerNestNameSort.php
+++ b/app/Models/Sorts/ServerNestNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerNestNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('nests', 'servers.nest_id', '=', 'nests.id')
+            ->orderBy('nests.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerNodeNameSort.php
+++ b/app/Models/Sorts/ServerNodeNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerNodeNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('nodes', 'servers.node_id', '=', 'nodes.id')
+            ->orderBy('nodes.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerOwnerNameSort.php
+++ b/app/Models/Sorts/ServerOwnerNameSort.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerOwnerNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('users', 'servers.owner_id', '=', 'users.id')
+            ->orderBy('users.name_first', $direction)
+            ->orderBy('users.name_last', $direction)
+            ->select('servers.*');
+    }
+}

--- a/database/Seeders/TestUserSeeder.php
+++ b/database/Seeders/TestUserSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Ramsey\Uuid\Uuid;
+use Pterodactyl\Models\User;
+use Illuminate\Database\Seeder;
+
+class TestUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::query()->updateOrCreate(['email' => 'admin@hydrodactyl.dev'], [
+            'uuid' => Uuid::uuid4()->toString(),
+            'username' => 'admin',
+            'email' => 'admin@hydrodactyl.dev',
+            'name_first' => 'Admin',
+            'name_last' => 'User',
+            'password' => bcrypt('admin'),
+            'language' => 'en',
+            'root_admin' => true,
+            'use_totp' => false,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        User::query()->updateOrCreate(['email' => 'test@hydrodactyl.dev'], [
+            'uuid' => Uuid::uuid4()->toString(),
+            'username' => 'test',
+            'email' => 'test@hydrodactyl.dev',
+            'name_first' => 'Test',
+            'name_last' => 'User',
+            'password' => bcrypt('test'),
+            'language' => 'en',
+            'root_admin' => false,
+            'use_totp' => false,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -43,12 +43,17 @@ services:
             <<: *db-environment
             MYSQL_DATABASE: 'panel'
             MYSQL_USER: 'pterodactyl'
-        ports:
-            - '3306:3306'
+        # Port 3306 is exposed internally for the panel service; no host mapping needed in development
+        expose:
+            - '3306'
     cache:
         image: redis:alpine
         restart: always
     panel:
+        build:
+            context: .
+            args:
+                DEV: "true"
         image: hydrodactyl:develop
         restart: always
         ports:

--- a/resources/scripts/api/getFilterOptions.ts
+++ b/resources/scripts/api/getFilterOptions.ts
@@ -1,0 +1,28 @@
+import http from '@/api/http';
+
+export interface FilterOption {
+    value: number;
+    label: string;
+}
+
+export interface FilterOptions {
+    owners: FilterOption[];
+    nests: FilterOption[];
+    eggs: FilterOption[];
+    nodes: FilterOption[];
+}
+
+export default async (): Promise<FilterOptions> => {
+    return new Promise((resolve, reject) => {
+        http.get('/api/client/filter-options')
+            .then(({ data }) =>
+                resolve({
+                    owners: data.attributes?.owners || [],
+                    nests: data.attributes?.nests || [],
+                    eggs: data.attributes?.eggs || [],
+                    nodes: data.attributes?.nodes || [],
+                }),
+            )
+            .catch(reject);
+    });
+};

--- a/resources/scripts/api/getServers.ts
+++ b/resources/scripts/api/getServers.ts
@@ -11,7 +11,6 @@ interface QueryParams {
     page?: number;
     type?: string;
     sort?: string;
-    sortDirection?: 'asc' | 'desc';
     filterField?: string;
     filterValue?: string | number;
 }
@@ -19,14 +18,14 @@ interface QueryParams {
 export default ({
     query,
     sort,
-    sortDirection,
     filterField,
     filterValue,
     ...params
 }: QueryParams): Promise<PaginatedResult<Server>> => {
     const sorts: Record<string, 'asc' | 'desc'> = {};
     if (sort) {
-        sorts[sort] = sortDirection || 'asc';
+        const dir = sort.startsWith('-') ? 'desc' : 'asc';
+        sorts[dir === 'desc' ? sort.slice(1) : sort] = dir;
     }
 
     const filters: Record<string, string | number> = {};

--- a/resources/scripts/api/getServers.ts
+++ b/resources/scripts/api/getServers.ts
@@ -1,23 +1,53 @@
-import http, { getPaginationSet, type PaginatedResult } from '@/api/http';
+import http, {
+    type FractalResponseData,
+    getPaginationSet,
+    type PaginatedResult,
+    withQueryBuilderParams,
+} from '@/api/http';
 import { rawDataToServerObject, type Server } from '@/api/server/getServer';
 
 interface QueryParams {
     query?: string;
     page?: number;
     type?: string;
+    sort?: string;
+    sortDirection?: 'asc' | 'desc';
+    filterField?: string;
+    filterValue?: string | number;
 }
 
-export default ({ query, ...params }: QueryParams): Promise<PaginatedResult<Server>> => {
+export default ({
+    query,
+    sort,
+    sortDirection,
+    filterField,
+    filterValue,
+    ...params
+}: QueryParams): Promise<PaginatedResult<Server>> => {
+    const sorts: Record<string, 'asc' | 'desc'> = {};
+    if (sort) {
+        sorts[sort] = sortDirection || 'asc';
+    }
+
+    const filters: Record<string, string | number> = {};
+    if (query) {
+        filters['*'] = query;
+    }
+    if (filterField && filterValue !== undefined && filterValue !== '') {
+        filters[filterField] = filterValue;
+    }
+
     return new Promise((resolve, reject) => {
         http.get('/api/client', {
-            params: {
-                'filter[*]': query,
-                ...params,
-            },
+            params: withQueryBuilderParams({
+                page: params.page,
+                sorts: Object.keys(sorts).length > 0 ? sorts : undefined,
+                filters: Object.keys(filters).length > 0 ? filters : undefined,
+            }),
         })
             .then(({ data }) =>
                 resolve({
-                    items: (data.data || []).map((datum: any) => rawDataToServerObject(datum)),
+                    items: (data.data || []).map((datum: FractalResponseData) => rawDataToServerObject(datum)),
                     pagination: getPaginationSet(data.meta.pagination),
                 }),
             )

--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -1,5 +1,3 @@
-import { ArrowDown01Icon, FilterIcon } from '@hugeicons/core-free-icons';
-import { HugeiconsIcon } from '@hugeicons/react';
 import { useStoreState } from 'easy-peasy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -13,36 +11,30 @@ import ServerRow from '@/components/dashboard/ServerRow';
 import PageContentBlock from '@/components/elements/PageContentBlock';
 import Pagination from '@/components/elements/Pagination';
 import { Tabs, TabsList, TabsTrigger } from '@/components/elements/Tabs';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useHeader } from '@/contexts/HeaderContext';
 
 import useFlash from '@/plugins/useFlash';
 import { usePersistedState } from '@/plugins/usePersistedState';
 
-import { Button } from '../ui/button';
 import FilterDropdown from './header/FilterDropdown';
 import HeaderCentered from './header/HeaderCentered';
+import OwnerFilterDropdown, { type OwnerFilterValue } from './header/OwnerFilterDropdown';
 import SearchSection from './header/SearchSection';
-import SortDropdown, { type SortOption } from './header/SortDropdown';
+import SortDropdown, { type SortPreset } from './header/SortDropdown';
 
-const SORT_OPTIONS: SortOption[] = [
-    { value: 'name', label: 'Server Name' },
-    { value: 'owner_name', label: 'Owner' },
-    { value: 'nest_name', label: 'Nest' },
-    { value: 'egg_name', label: 'Egg' },
-    { value: 'node_name', label: 'Node' },
-    { value: 'uuidShort', label: 'Identifier' },
-    { value: 'status', label: 'Status' },
-    { value: 'created_at', label: 'Creation Date' },
-    { value: 'updated_at', label: 'Last Updated' },
-    { value: 'memory', label: 'Memory' },
-    { value: 'disk', label: 'Disk' },
-    { value: 'cpu', label: 'CPU' },
+const SORT_PRESETS: SortPreset[] = [
+    { value: 'name', label: 'A → Z' },
+    { value: '-name', label: 'Z → A' },
+    { value: 'created_at', label: 'Oldest → Newest' },
+    { value: '-created_at', label: 'Newest → Oldest' },
+    { value: 'status', label: 'Status ▲' },
+    { value: '-status', label: 'Status ▼' },
+    { value: 'memory', label: 'Memory ↑' },
+    { value: '-memory', label: 'Memory ↓' },
+    { value: 'disk', label: 'Disk ↑' },
+    { value: '-disk', label: 'Disk ↓' },
+    { value: 'cpu', label: 'CPU ↑' },
+    { value: '-cpu', label: 'CPU ↓' },
 ];
 
 type FilterCategory = 'owner_id' | 'nest_id' | 'egg_id' | 'node_id';
@@ -55,10 +47,7 @@ const DashboardContainer = () => {
     const { clearFlashes, clearAndAddHttpError } = useFlash();
     const uuid = useStoreState((state) => state.user.data!.uuid);
     const rootAdmin = useStoreState((state) => state.user.data!.rootAdmin);
-    const [serverViewMode, setServerViewMode] = usePersistedState<'owner' | 'admin-all' | 'all'>(
-        `${uuid}:server_view_mode`,
-        'owner',
-    );
+    const [ownerFilter, setOwnerFilter] = usePersistedState<OwnerFilterValue>(`${uuid}:server_view_mode`, 'owner');
 
     const { setHeaderActions, clearHeaderActions } = useHeader();
 
@@ -68,8 +57,7 @@ const DashboardContainer = () => {
     );
 
     const [searchQuery, setSearchQuery] = useState('');
-    const [sortField, setSortField] = useState('');
-    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+    const [sortValue, setSortValue] = useState('');
     const [filterField, setFilterField] = useState<FilterCategory | undefined>(undefined);
     const [filterValue, setFilterValue] = useState<number | undefined>(undefined);
 
@@ -77,33 +65,32 @@ const DashboardContainer = () => {
         revalidateOnMount: true,
     });
 
-    const getApiType = (): string | undefined => {
-        if (serverViewMode === 'owner') return 'owner';
-        if (serverViewMode === 'admin-all') return 'admin-all';
-        if (serverViewMode === 'all') return 'all';
-        return undefined;
-    };
-
     const { data: servers, error } = useSWR<PaginatedResult<Server>>(
-        ['/api/client/servers', serverViewMode, page, searchQuery, sortField, sortDirection, filterField, filterValue],
+        ['/api/client/servers', ownerFilter, page, searchQuery, sortValue, filterField, filterValue],
         () =>
             getServers({
                 page,
-                type: getApiType(),
+                type: ownerFilter,
                 query: searchQuery || undefined,
-                sort: sortField || undefined,
-                sortDirection: sortField ? sortDirection : undefined,
+                sort: sortValue || undefined,
                 filterField: filterField,
                 filterValue: filterValue,
             }),
         { revalidateOnFocus: false },
     );
 
-    const handleSortChange = useCallback((field: string, direction: 'asc' | 'desc') => {
-        setSortField(field);
-        setSortDirection(direction);
+    const handleSortChange = useCallback((value: string) => {
+        setSortValue(value);
         setPage(1);
     }, []);
+
+    const handleOwnerFilterChange = useCallback(
+        (value: OwnerFilterValue) => {
+            setOwnerFilter(value);
+            setPage(1);
+        },
+        [setOwnerFilter],
+    );
 
     const handleFilterChange = useCallback((field: FilterCategory | undefined, value: number | undefined) => {
         setFilterField(field);
@@ -151,52 +138,9 @@ const DashboardContainer = () => {
         [dashboardDisplayOption, setDashboardDisplayOption],
     );
 
-    const filterDropdown = useMemo(
-        () => (
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button
-                        size={'sm'}
-                        variant={'secondary'}
-                        className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'
-                    >
-                        <div className='flex flex-row items-center gap-1'>
-                            <div className='flex flex-row items-center gap-1.5'>
-                                <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
-                                Filter
-                            </div>
-                            <HugeiconsIcon size={16} strokeWidth={2} icon={ArrowDown01Icon} />
-                        </div>
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
-                    <DropdownMenuItem
-                        onSelect={() => setServerViewMode('owner')}
-                        className={serverViewMode === 'owner' ? 'bg-accent/20' : ''}
-                    >
-                        Your Servers Only
-                    </DropdownMenuItem>
-
-                    {rootAdmin && (
-                        <>
-                            <DropdownMenuItem
-                                onSelect={() => setServerViewMode('admin-all')}
-                                className={serverViewMode === 'admin-all' ? 'bg-accent/20' : ''}
-                            >
-                                All Servers (Admin)
-                            </DropdownMenuItem>
-                        </>
-                    )}
-                    <DropdownMenuItem
-                        onSelect={() => setServerViewMode('all')}
-                        className={serverViewMode === 'all' ? 'bg-accent/20' : ''}
-                    >
-                        All Servers
-                    </DropdownMenuItem>
-                </DropdownMenuContent>
-            </DropdownMenu>
-        ),
-        [rootAdmin, serverViewMode, setServerViewMode],
+    const ownerFilterDropdown = useMemo(
+        () => <OwnerFilterDropdown value={ownerFilter} rootAdmin={rootAdmin} onChange={handleOwnerFilterChange} />,
+        [ownerFilter, rootAdmin, handleOwnerFilterChange],
     );
 
     const entityFilterDropdown = useMemo(
@@ -212,28 +156,21 @@ const DashboardContainer = () => {
     );
 
     const sortDropdown = useMemo(
-        () => (
-            <SortDropdown
-                options={SORT_OPTIONS}
-                value={sortField}
-                direction={sortDirection}
-                onSortChange={handleSortChange}
-            />
-        ),
-        [sortField, sortDirection, handleSortChange],
+        () => <SortDropdown presets={SORT_PRESETS} value={sortValue} onSortChange={handleSortChange} />,
+        [sortValue, handleSortChange],
     );
 
     useEffect(() => {
-        setHeaderActions([searchSection, viewTabs, entityFilterDropdown, sortDropdown, filterDropdown]);
+        setHeaderActions([searchSection, viewTabs, ownerFilterDropdown, entityFilterDropdown, sortDropdown]);
         return () => clearHeaderActions();
     }, [
         setHeaderActions,
         clearHeaderActions,
         searchSection,
         viewTabs,
+        ownerFilterDropdown,
         entityFilterDropdown,
         sortDropdown,
-        filterDropdown,
     ]);
 
     useEffect(() => {
@@ -300,14 +237,14 @@ const DashboardContainer = () => {
                                 className={`text-center text-sm text-zinc-400 absolute w-full left-1/2 -translate-x-1/2`}
                             >
                                 <p className='max-w-sm mx-auto mb-5'>
-                                    {serverViewMode === 'admin-all'
+                                    {ownerFilter === 'admin-all'
                                         ? 'There are no other servers to display.'
-                                        : serverViewMode === 'all'
+                                        : ownerFilter === 'all'
                                           ? 'No Server Shared With your Account'
                                           : 'There are no servers associated with your account.'}
                                 </p>
                                 <h3 className='text-lg font-medium text-zinc-200 mb-2'>
-                                    {serverViewMode === 'admin-all' ? 'No other servers found' : 'No servers found'}
+                                    {ownerFilter === 'admin-all' ? 'No other servers found' : 'No servers found'}
                                 </h3>
                             </div>
                         )

--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -4,6 +4,8 @@ import { useStoreState } from 'easy-peasy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
+import getFilterOptions from '@/api/getFilterOptions';
 import getServers from '@/api/getServers';
 import type { PaginatedResult } from '@/api/http';
 import type { Server } from '@/api/server/getServer';
@@ -23,8 +25,27 @@ import useFlash from '@/plugins/useFlash';
 import { usePersistedState } from '@/plugins/usePersistedState';
 
 import { Button } from '../ui/button';
+import FilterDropdown from './header/FilterDropdown';
 import HeaderCentered from './header/HeaderCentered';
 import SearchSection from './header/SearchSection';
+import SortDropdown, { type SortOption } from './header/SortDropdown';
+
+const SORT_OPTIONS: SortOption[] = [
+    { value: 'name', label: 'Server Name' },
+    { value: 'owner_name', label: 'Owner' },
+    { value: 'nest_name', label: 'Nest' },
+    { value: 'egg_name', label: 'Egg' },
+    { value: 'node_name', label: 'Node' },
+    { value: 'uuidShort', label: 'Identifier' },
+    { value: 'status', label: 'Status' },
+    { value: 'created_at', label: 'Creation Date' },
+    { value: 'updated_at', label: 'Last Updated' },
+    { value: 'memory', label: 'Memory' },
+    { value: 'disk', label: 'Disk' },
+    { value: 'cpu', label: 'CPU' },
+];
+
+type FilterCategory = 'owner_id' | 'nest_id' | 'egg_id' | 'node_id';
 
 const DashboardContainer = () => {
     const { search } = useLocation();
@@ -34,7 +55,6 @@ const DashboardContainer = () => {
     const { clearFlashes, clearAndAddHttpError } = useFlash();
     const uuid = useStoreState((state) => state.user.data!.uuid);
     const rootAdmin = useStoreState((state) => state.user.data!.rootAdmin);
-    const [showOnlyAdmin, setShowOnlyAdmin] = usePersistedState(`${uuid}:show_all_servers`, false);
     const [serverViewMode, setServerViewMode] = usePersistedState<'owner' | 'admin-all' | 'all'>(
         `${uuid}:server_view_mode`,
         'owner',
@@ -47,30 +67,62 @@ const DashboardContainer = () => {
         'list',
     );
 
+    const [searchQuery, setSearchQuery] = useState('');
+    const [sortField, setSortField] = useState('');
+    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+    const [filterField, setFilterField] = useState<FilterCategory | undefined>(undefined);
+    const [filterValue, setFilterValue] = useState<number | undefined>(undefined);
+
+    const { data: filterOptions } = useSWRImmutable('server:filter-options', () => getFilterOptions(), {
+        revalidateOnMount: true,
+    });
+
     const getApiType = (): string | undefined => {
-        if (serverViewMode === 'owner') return 'owner'; // Servers the User owns
-        if (serverViewMode === 'admin-all') return 'admin-all'; // All servers(Admin only)
-        if (serverViewMode === 'all') return 'all'; // All servers user has Access too. (Subusers and owned)
+        if (serverViewMode === 'owner') return 'owner';
+        if (serverViewMode === 'admin-all') return 'admin-all';
+        if (serverViewMode === 'all') return 'all';
         return undefined;
     };
 
     const { data: servers, error } = useSWR<PaginatedResult<Server>>(
-        ['/api/client/servers', serverViewMode, page],
-        () => getServers({ page, type: getApiType() }),
+        ['/api/client/servers', serverViewMode, page, searchQuery, sortField, sortDirection, filterField, filterValue],
+        () =>
+            getServers({
+                page,
+                type: getApiType(),
+                query: searchQuery || undefined,
+                sort: sortField || undefined,
+                sortDirection: sortField ? sortDirection : undefined,
+                filterField: filterField,
+                filterValue: filterValue,
+            }),
         { revalidateOnFocus: false },
     );
 
-    const handleFilterToggle = useCallback(() => {
-        setShowOnlyAdmin((s) => !s);
-    }, [setShowOnlyAdmin]);
+    const handleSortChange = useCallback((field: string, direction: 'asc' | 'desc') => {
+        setSortField(field);
+        setSortDirection(direction);
+        setPage(1);
+    }, []);
+
+    const handleFilterChange = useCallback((field: FilterCategory | undefined, value: number | undefined) => {
+        setFilterField(field);
+        setFilterValue(value);
+        setPage(1);
+    }, []);
+
+    const handleSearch = useCallback((value: string) => {
+        setSearchQuery(value);
+        setPage(1);
+    }, []);
 
     const searchSection = useMemo(
         () => (
             <HeaderCentered>
-                <SearchSection className='max-w-240 xl:w-[30vw] hidden md:flex ' />
+                <SearchSection className='max-w-240 xl:w-[30vw] hidden md:flex' onSearch={handleSearch} />
             </HeaderCentered>
         ),
-        [],
+        [handleSearch],
     );
 
     const viewTabs = useMemo(
@@ -88,7 +140,7 @@ const DashboardContainer = () => {
                     <TabsTrigger aria-label='View servers in a grid layout.' value='grid'>
                         <svg width='13' height='14' viewBox='0 0 16 17' fill='none' xmlns='http://www.w3.org/2000/svg'>
                             <path
-                                d='M1 3.1C1 2.54 1 2.26 1.109 2.046C1.20487 1.85785 1.35785 1.70487 1.546 1.609C1.76 1.5 2.04 1.5 2.6 1.5H5.4C5.96 1.5 6.24 1.5 6.454 1.609C6.64215 1.70487 6.79513 1.85785 6.891 2.046C7 2.26 7 2.54 7 3.1V3.9C7 4.46 7 4.74 6.891 4.954C6.79513 5.14215 6.64215 5.29513 6.454 5.391C6.24 5.5 5.96 5.5 5.4 5.5H2.6C2.04 5.5 1.76 5.5 1.546 5.391C1.35785 5.29513 1.20487 5.14215 1.109 4.954C1 4.74 1 4.46 1 3.9V3.1ZM9 3.1C9 2.54 9 2.26 9.109 2.046C9.20487 1.85785 9.35785 1.70487 9.546 1.609C9.76 1.5 10.04 1.5 10.6 1.5H13.4C13.96 1.5 14.24 1.5 14.454 1.609C14.6422 1.70487 14.7951 1.85785 14.891 2.046C15 2.26 15 2.54 15 3.1V3.9C15 4.46 15 4.74 14.891 4.954C14.7951 5.14215 14.6422 5.29513 14.454 5.391C14.24 5.5 13.96 5.5 13.4 5.5H10.6C10.04 5.5 9.76 5.5 9.546 5.391C9.35785 5.29513 9.20487 5.14215 9.109 4.954C9 4.74 9 4.46 9 3.9V3.1ZM1 8.1C1 7.54 1 7.26 1.109 7.046C1.20487 6.85785 1.35785 6.70487 1.546 6.609C1.76 6.5 2.04 6.5 2.6 6.5H5.4C5.96 6.5 6.24 6.5 6.454 6.609C6.64215 6.70487 6.79513 6.85785 6.891 7.046C7 7.26 7 7.54 7 8.1V8.9C7 9.46 7 9.74 6.891 9.954C6.79513 10.1422 6.64215 10.2951 6.454 10.391C6.24 10.5 5.96 10.5 5.4 10.5H2.6C2.04 10.5 1.76 10.5 1.546 10.391C1.35785 10.2951 1.20487 10.1422 1.109 9.954C1 9.74 1 9.46 1 8.9V8.1ZM9 8.1C9 7.54 9 7.26 9.109 7.046C9.20487 6.85785 9.35785 6.70487 9.546 6.609C9.76 6.5 10.04 6.5 10.6 6.5H13.4C13.96 6.5 14.24 6.5 14.454 6.609C14.6422 6.70487 14.7951 6.85785 14.891 7.046C15 7.26 15 7.54 15 8.1V8.9C15 9.46 15 9.74 14.891 9.954C14.7951 10.1422 14.6422 10.2951 14.454 10.391C14.24 10.5 13.96 10.5 13.4 10.5H10.6C10.04 10.5 9.76 10.5 9.546 10.391C9.35785 10.2951 9.20487 10.1422 9.109 9.954C9 9.74 9 9.46 9 8.9V8.1ZM1 13.1C1 12.54 1 12.26 1.109 12.046C1.20487 11.8578 1.35785 11.7049 1.546 11.609C1.76 11.5 2.04 11.5 2.6 11.5H5.4C5.96 11.5 6.24 11.5 6.454 11.609C6.64215 11.7049 6.79513 11.8578 6.891 12.046C7 12.26 7 12.54 7 13.1V13.9C7 14.46 7 14.74 6.891 14.954C6.79513 15.1422 6.64215 15.2951 6.454 15.391C6.24 15.5 5.96 15.5 5.4 15.5H2.6C2.04 15.5 1.76 15.5 1.546 15.391C1.35785 15.2951 1.20487 15.1422 1.109 14.954C1 14.74 1 14.46 1 13.9V13.1ZM9 13.1C9 12.54 9 12.26 9.109 12.046C9.20487 11.8578 9.35785 11.7049 9.546 11.609C9.76 11.5 10.04 11.5 10.6 11.5H13.4C13.96 11.5 14.24 11.5 14.454 11.609C14.6422 11.7049 14.7951 11.8578 14.891 12.046C15 12.26 15 12.54 15 13.1V13.9C15 14.46 15 14.74 14.891 14.954C14.7951 15.1422 14.6422 15.2951 14.454 15.391C14.24 15.5 13.96 15.5 13.4 15.5H10.6C10.04 15.5 9.76 15.5 9.546 15.391C9.35785 15.2951 1.20487 15.1422 9.109 14.954C9 14.74 9 14.46 9 13.9V13.1Z'
+                                d='M1 3.1C1 2.54 1 2.26 1.109 2.046C1.20487 1.85785 1.35785 1.70487 1.546 1.609C1.76 1.5 2.04 1.5 2.6 1.5H5.4C5.96 1.5 6.24 1.5 6.454 1.609C6.64215 1.70487 6.79513 1.85785 6.891 2.046C7 2.26 7 2.54 7 3.1V3.9C7 4.46 7 4.74 6.891 4.954C6.79513 5.14215 6.64215 5.29513 6.454 5.391C6.24 5.5 5.96 5.5 5.4 5.5H2.6C2.04 5.5 1.76 5.5 1.546 5.391C1.35785 5.29513 1.20487 5.14215 1.109 4.954C1 4.74 1 4.46 1 3.9V3.1ZM9 3.1C9 2.54 9 2.26 9.109 2.046C9.20487 1.85785 9.35785 1.70487 9.546 1.609C9.76 1.5 10.04 1.5 10.6 1.5H13.4C13.96 1.5 14.24 1.5 14.454 1.609C14.6422 1.70487 14.7951 1.85785 14.891 2.046C15 2.26 15 2.54 15 3.1V3.9C15 4.46 15 4.74 14.891 4.954C14.7951 5.14215 14.6422 5.29513 14.454 5.391C14.24 5.5 13.96 5.5 13.4 5.5H10.6C10.04 5.5 9.76 5.5 9.546 5.391C9.35785 5.29513 9.20487 5.14215 9.109 4.954C9 4.74 9 4.46 9 3.9V3.1Z'
                                 fill='currentColor'
                             />
                         </svg>
@@ -108,7 +160,7 @@ const DashboardContainer = () => {
                         variant={'secondary'}
                         className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'
                     >
-                        <div className='flex flex-row items-center gap-1 '>
+                        <div className='flex flex-row items-center gap-1'>
                             <div className='flex flex-row items-center gap-1.5'>
                                 <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
                                 Filter
@@ -144,13 +196,45 @@ const DashboardContainer = () => {
                 </DropdownMenuContent>
             </DropdownMenu>
         ),
-        [rootAdmin, showOnlyAdmin],
+        [rootAdmin, serverViewMode, setServerViewMode],
+    );
+
+    const entityFilterDropdown = useMemo(
+        () => (
+            <FilterDropdown
+                filterOptions={filterOptions || { owners: [], nests: [], eggs: [], nodes: [] }}
+                activeField={filterField}
+                activeValue={filterValue}
+                onFilterChange={handleFilterChange}
+            />
+        ),
+        [filterOptions, filterField, filterValue, handleFilterChange],
+    );
+
+    const sortDropdown = useMemo(
+        () => (
+            <SortDropdown
+                options={SORT_OPTIONS}
+                value={sortField}
+                direction={sortDirection}
+                onSortChange={handleSortChange}
+            />
+        ),
+        [sortField, sortDirection, handleSortChange],
     );
 
     useEffect(() => {
-        setHeaderActions([searchSection, viewTabs, filterDropdown]);
+        setHeaderActions([searchSection, viewTabs, entityFilterDropdown, sortDropdown, filterDropdown]);
         return () => clearHeaderActions();
-    }, [setHeaderActions, clearHeaderActions, searchSection, viewTabs, filterDropdown]);
+    }, [
+        setHeaderActions,
+        clearHeaderActions,
+        searchSection,
+        viewTabs,
+        entityFilterDropdown,
+        sortDropdown,
+        filterDropdown,
+    ]);
 
     useEffect(() => {
         if (!servers) return;
@@ -160,9 +244,6 @@ const DashboardContainer = () => {
     }, [servers]);
 
     useEffect(() => {
-        // Don't use react-router to handle changing this part of the URL, otherwise it
-        // triggers a needless re-render. We just want to track this in the URL incase the
-        // user refreshes the page.
         window.history.replaceState(null, document.title, `/${page <= 1 ? '' : `?page=${page}`}`);
     }, [page]);
 

--- a/resources/scripts/components/dashboard/header/FilterDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/FilterDropdown.tsx
@@ -1,0 +1,126 @@
+import { FilterIcon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo } from 'react';
+import type { FilterOption, FilterOptions } from '@/api/getFilterOptions';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+type FilterCategory = 'owner_id' | 'nest_id' | 'egg_id' | 'node_id';
+
+interface CategoryGroup {
+    category: FilterCategory;
+    label: string;
+    options: FilterOption[];
+}
+
+interface FilterDropdownProps {
+    filterOptions: FilterOptions;
+    activeField?: FilterCategory;
+    activeValue?: number;
+    onFilterChange: (field: FilterCategory | undefined, value: number | undefined) => void;
+}
+
+const FilterDropdown = ({ filterOptions, activeField, activeValue, onFilterChange }: FilterDropdownProps) => {
+    const groups: CategoryGroup[] = useMemo(
+        () => [
+            { category: 'owner_id', label: 'Owner', options: filterOptions.owners },
+            { category: 'nest_id', label: 'Nest', options: filterOptions.nests },
+            { category: 'egg_id', label: 'Egg', options: filterOptions.eggs },
+            { category: 'node_id', label: 'Node', options: filterOptions.nodes },
+        ],
+        [filterOptions],
+    );
+
+    const activeGroup = useMemo(() => groups.find((g) => g.category === activeField), [groups, activeField]);
+
+    const activeLabel = useMemo(() => {
+        if (!activeGroup || activeValue === undefined) return null;
+        const option = activeGroup.options.find((o) => o.value === activeValue);
+        return option ? `${activeGroup.label}: ${option.label}` : null;
+    }, [activeGroup, activeValue]);
+
+    const hasActiveFilter = activeField && activeValue !== undefined;
+    const totalOptions = groups.reduce((sum, g) => sum + g.options.length, 0);
+    const allEmpty = totalOptions === 0;
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    size={'sm'}
+                    variant={'secondary'}
+                    className={`px-1 pl-3 gap-1 rounded-full hover:cursor-pointer ${hasActiveFilter ? 'border-accent/50' : ''}`}
+                >
+                    <div className='flex flex-row items-center gap-1'>
+                        <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
+                        {activeLabel || 'Filter'}
+                    </div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+                className='flex flex-col gap-1 z-99999 hover:cursor-pointer max-h-[60vh] overflow-y-auto'
+                sideOffset={8}
+            >
+                {allEmpty ? (
+                    <DropdownMenuItem disabled className='opacity-50'>
+                        No filter options available
+                    </DropdownMenuItem>
+                ) : (
+                    groups.map((group) =>
+                        group.options.length === 0 ? null : (
+                            <DropdownMenuSub key={group.category}>
+                                <DropdownMenuSubTrigger className='font-medium'>
+                                    {group.label} ({group.options.length})
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent className='max-h-[40vh] overflow-y-auto'>
+                                    <DropdownMenuItem
+                                        onSelect={() => onFilterChange(undefined, undefined)}
+                                        className='text-red-400 text-xs'
+                                    >
+                                        Clear this filter
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                    {group.options.map((option) => (
+                                        <DropdownMenuItem
+                                            key={`${group.category}-${option.value}`}
+                                            onSelect={() => onFilterChange(group.category, option.value)}
+                                            className={
+                                                activeField === group.category && activeValue === option.value
+                                                    ? 'bg-accent/20'
+                                                    : ''
+                                            }
+                                        >
+                                            {option.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                        ),
+                    )
+                )}
+                {hasActiveFilter && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            onSelect={() => onFilterChange(undefined, undefined)}
+                            className='text-red-400'
+                        >
+                            Clear All Filters
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default FilterDropdown;

--- a/resources/scripts/components/dashboard/header/OwnerFilterDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/OwnerFilterDropdown.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export type OwnerFilterValue = 'owner' | 'shared' | 'all' | 'admin-all';
+
+interface OwnerFilterDropdownProps {
+    value: OwnerFilterValue;
+    rootAdmin: boolean;
+    onChange: (value: OwnerFilterValue) => void;
+}
+
+const LABELS: Record<OwnerFilterValue, string> = {
+    owner: 'My Servers',
+    shared: 'Shared Only',
+    all: 'All',
+    'admin-all': 'All (Admin)',
+};
+
+const OwnerFilterDropdown = ({ value, rootAdmin, onChange }: OwnerFilterDropdownProps) => {
+    const items = useMemo(() => {
+        const list: OwnerFilterValue[] = ['owner', 'shared', 'all'];
+        if (rootAdmin) list.push('admin-all');
+        return list;
+    }, [rootAdmin]);
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button size={'sm'} variant={'secondary'} className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'>
+                    <div className='flex flex-row items-center gap-1'>{LABELS[value]}</div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
+                {items.map((item) => (
+                    <DropdownMenuItem
+                        key={item}
+                        onSelect={() => onChange(item)}
+                        className={value === item ? 'bg-accent/20' : ''}
+                    >
+                        {LABELS[item]}
+                    </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => onChange('all')} className='text-red-400'>
+                    Reset
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default OwnerFilterDropdown;

--- a/resources/scripts/components/dashboard/header/SearchSection.tsx
+++ b/resources/scripts/components/dashboard/header/SearchSection.tsx
@@ -17,10 +17,12 @@ SearchIcon.displayName = 'SearchIcon';
 
 interface SearchSectionProps {
     className?: string;
+    onSearch?: (value: string) => void;
 }
 
-const SearchSection = memo(({ className }: SearchSectionProps) => {
+const SearchSection = memo(({ className, onSearch }: SearchSectionProps) => {
     const [searchValue, setSearchValue] = useState('');
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
     const inputRef = useRef(null);
 
@@ -39,6 +41,19 @@ const SearchSection = memo(({ className }: SearchSectionProps) => {
         };
     }, []);
 
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setSearchValue(value);
+
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+        }
+
+        debounceRef.current = setTimeout(() => {
+            onSearch?.(value);
+        }, 300);
+    };
+
     return (
         <div className={`flex items-center gap-2 h-full group ${className || ''}`}>
             <div className='relative w-3/4 transition-all duration-200 ease-out group group-focus-within:w-full mx-auto'>
@@ -48,9 +63,7 @@ const SearchSection = memo(({ className }: SearchSectionProps) => {
                     type='text'
                     placeholder='Search servers...'
                     value={searchValue}
-                    onChange={(e) => {
-                        setSearchValue(e.target.value);
-                    }}
+                    onChange={handleChange}
                     className='pl-10 pr-16 mx-auto w-full group-focus-within:w-full transition-all duration-200 ease-out '
                 />
                 <SearchIcon />

--- a/resources/scripts/components/dashboard/header/SortDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/SortDropdown.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown01Icon, ArrowUp01Icon, Sorting01Icon } from '@hugeicons/core-free-icons';
+import { Sorting01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
@@ -10,67 +10,47 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-export interface SortOption {
+export interface SortPreset {
     value: string;
     label: string;
 }
 
 interface SortDropdownProps {
-    options: SortOption[];
+    presets: SortPreset[];
     value?: string;
-    direction?: 'asc' | 'desc';
-    onSortChange: (value: string, direction: 'asc' | 'desc') => void;
+    onSortChange: (value: string) => void;
 }
 
-const SortDropdown = ({ options, value, direction, onSortChange }: SortDropdownProps) => {
-    const currentOption = useMemo(() => options.find((o) => o.value === value), [options, value]);
-
-    const handleSelect = (selectedValue: string) => {
-        if (value === selectedValue) {
-            onSortChange(selectedValue, direction === 'asc' ? 'desc' : 'asc');
-        } else {
-            onSortChange(selectedValue, 'asc');
-        }
-    };
-
-    const currentLabel = currentOption ? `${currentOption.label} (${direction === 'desc' ? 'Z→A' : 'A→Z'})` : 'Sort';
+const SortDropdown = ({ presets, value, onSortChange }: SortDropdownProps) => {
+    const currentPreset = useMemo(() => presets.find((p) => p.value === value), [presets, value]);
 
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button size={'sm'} variant={'secondary'} className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'>
                     <div className='flex flex-row items-center gap-1'>
-                        <div className='flex flex-row items-center gap-1.5'>
-                            <HugeiconsIcon size={16} strokeWidth={2} icon={Sorting01Icon} className='size-4' />
-                            {currentLabel}
-                        </div>
-                        <HugeiconsIcon
-                            size={16}
-                            strokeWidth={2}
-                            icon={direction === 'desc' ? ArrowUp01Icon : ArrowDown01Icon}
-                        />
+                        <HugeiconsIcon size={16} strokeWidth={2} icon={Sorting01Icon} className='size-4' />
+                        {currentPreset?.label || 'Sort'}
                     </div>
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
-                {options.map((option) => (
+                {presets.map((preset) => (
                     <DropdownMenuItem
-                        key={option.value}
-                        onSelect={() => handleSelect(option.value)}
-                        className={value === option.value ? 'bg-accent/20' : ''}
+                        key={preset.value}
+                        onSelect={() => onSortChange(preset.value)}
+                        className={value === preset.value ? 'bg-accent/20' : ''}
                     >
                         <span className='flex items-center justify-between w-full gap-4'>
-                            {option.label}
-                            {value === option.value && (
-                                <span className='text-xs opacity-60'>{direction === 'desc' ? 'Z→A' : 'A→Z'}</span>
-                            )}
+                            {preset.label}
+                            {value === preset.value && <span className='text-xs opacity-60'>&#10003;</span>}
                         </span>
                     </DropdownMenuItem>
                 ))}
                 {value && (
                     <>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onSelect={() => onSortChange('', 'asc')} className='text-red-400'>
+                        <DropdownMenuItem onSelect={() => onSortChange('')} className='text-red-400'>
                             Clear Sort
                         </DropdownMenuItem>
                     </>

--- a/resources/scripts/components/dashboard/header/SortDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/SortDropdown.tsx
@@ -1,0 +1,83 @@
+import { ArrowDown01Icon, ArrowUp01Icon, Sorting01Icon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export interface SortOption {
+    value: string;
+    label: string;
+}
+
+interface SortDropdownProps {
+    options: SortOption[];
+    value?: string;
+    direction?: 'asc' | 'desc';
+    onSortChange: (value: string, direction: 'asc' | 'desc') => void;
+}
+
+const SortDropdown = ({ options, value, direction, onSortChange }: SortDropdownProps) => {
+    const currentOption = useMemo(() => options.find((o) => o.value === value), [options, value]);
+
+    const handleSelect = (selectedValue: string) => {
+        if (value === selectedValue) {
+            onSortChange(selectedValue, direction === 'asc' ? 'desc' : 'asc');
+        } else {
+            onSortChange(selectedValue, 'asc');
+        }
+    };
+
+    const currentLabel = currentOption ? `${currentOption.label} (${direction === 'desc' ? 'Z→A' : 'A→Z'})` : 'Sort';
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button size={'sm'} variant={'secondary'} className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'>
+                    <div className='flex flex-row items-center gap-1'>
+                        <div className='flex flex-row items-center gap-1.5'>
+                            <HugeiconsIcon size={16} strokeWidth={2} icon={Sorting01Icon} className='size-4' />
+                            {currentLabel}
+                        </div>
+                        <HugeiconsIcon
+                            size={16}
+                            strokeWidth={2}
+                            icon={direction === 'desc' ? ArrowUp01Icon : ArrowDown01Icon}
+                        />
+                    </div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
+                {options.map((option) => (
+                    <DropdownMenuItem
+                        key={option.value}
+                        onSelect={() => handleSelect(option.value)}
+                        className={value === option.value ? 'bg-accent/20' : ''}
+                    >
+                        <span className='flex items-center justify-between w-full gap-4'>
+                            {option.label}
+                            {value === option.value && (
+                                <span className='text-xs opacity-60'>{direction === 'desc' ? 'Z→A' : 'A→Z'}</span>
+                            )}
+                        </span>
+                    </DropdownMenuItem>
+                ))}
+                {value && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onSelect={() => onSortChange('', 'asc')} className='text-red-400'>
+                            Clear Sort
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default SortDropdown;

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -20,6 +20,7 @@ use Pterodactyl\Http\Middleware\Api\Client\Server\AuthenticateServerAccess;
 */
 
 Route::get('/', [Client\ClientController::class, 'index'])->name('api:client.index');
+Route::get('/filter-options', [Client\ClientController::class, 'filterOptions'])->name('api:client.filter-options');
 Route::get('/permissions', [Client\ClientController::class, 'permissions']);
 Route::get('/version', function () {
     return response()->json(['version' => config('app.version')]);

--- a/tests/Integration/Api/Client/ClientControllerTest.php
+++ b/tests/Integration/Api/Client/ClientControllerTest.php
@@ -330,6 +330,172 @@ class ClientControllerTest extends ClientApiIntegrationTestCase
         $response->assertJsonPath('data.0.attributes.relationships.allocations.data.0.attributes.notes', null);
     }
 
+    public function testServersAreSortedAscendingByName(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $servers = [
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Charlie']),
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Alpha']),
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Bravo']),
+        ];
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=name');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Alpha');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+        $response->assertJsonPath('data.2.attributes.name', 'Charlie');
+    }
+
+    public function testServersAreSortedDescendingByName(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $servers = [
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Charlie']),
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Alpha']),
+            $this->createServerModel(['user_id' => $user->id, 'name' => 'Bravo']),
+        ];
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=-name');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Charlie');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+        $response->assertJsonPath('data.2.attributes.name', 'Alpha');
+    }
+
+    public function testServersAreSortedByCreationDate(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $server1 = $this->createServerModel(['user_id' => $user->id, 'name' => 'Oldest']);
+        $server2 = $this->createServerModel(['user_id' => $user->id, 'name' => 'Middle']);
+        $server3 = $this->createServerModel(['user_id' => $user->id, 'name' => 'Newest']);
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=created_at');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Oldest');
+        $response->assertJsonPath('data.1.attributes.name', 'Middle');
+        $response->assertJsonPath('data.2.attributes.name', 'Newest');
+    }
+
+    public function testFilteringByOwnerId(): void
+    {
+        /** @var User[] $users */
+        $users = User::factory()->times(2)->create();
+
+        $this->createServerModel(['user_id' => $users[0]->id, 'name' => 'OwnerIsUser0']);
+        $this->createServerModel(['user_id' => $users[1]->id, 'name' => 'OwnerIsUser1']);
+
+        $response = $this->actingAs($users[0])->getJson('/api/client?filter[owner_id]=' . $users[0]->id);
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'OwnerIsUser0');
+    }
+
+    public function testFilteringByNodeId(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $server1 = $this->createServerModel(['user_id' => $user->id, 'name' => 'OnNodeA']);
+        $server2 = $this->createServerModel(['user_id' => $user->id, 'name' => 'OnNodeB']);
+
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?filter[node_id]=' . $server1->node_id
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'OnNodeA');
+    }
+
+    public function testFilteringByNestAndEggId(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $server1 = $this->createServerModel(['user_id' => $user->id, 'name' => 'UsesDefaultEgg']);
+        $server2 = $this->createServerModel([
+            'user_id' => $user->id,
+            'name' => 'UsesDefaultEggToo',
+        ]);
+
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?filter[nest_id]=' . $server1->nest_id
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+    }
+
+    public function testSortingCombinedWithEntityFiltering(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        // Create node and allocations manually so both servers share the same node
+        $location = \Pterodactyl\Models\Location::factory()->create();
+        $node = \Pterodactyl\Models\Node::factory()->create(['location_id' => $location->id]);
+
+        $allocation1 = \Pterodactyl\Models\Allocation::factory()->create(['node_id' => $node->id]);
+        $allocation2 = \Pterodactyl\Models\Allocation::factory()->create(['node_id' => $node->id]);
+
+        $server1 = $this->createServerModel([
+            'user_id' => $user->id,
+            'name' => 'Bravo',
+            'node_id' => $node->id,
+            'allocation_id' => $allocation1->id,
+        ]);
+
+        $server2 = $this->createServerModel([
+            'user_id' => $user->id,
+            'name' => 'Alpha',
+            'node_id' => $node->id,
+            'allocation_id' => $allocation2->id,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?filter[node_id]=' . $node->id . '&sort=name'
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.attributes.name', 'Alpha');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+    }
+
+    public function testFilterOptionsEndpointReturnsStructuredData(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $this->createServerModel(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->getJson('/api/client/filter-options');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'object',
+            'attributes' => [
+                'owners',
+                'nests',
+                'eggs',
+                'nodes',
+            ],
+        ]);
+        $response->assertJsonPath('object', 'server_filter_options');
+    }
+
     public static function filterTypeDataProvider(): array
     {
         return [['admin'], ['admin-all']];


### PR DESCRIPTION
Adds server-side sorting, filtering, and search functionality to the dashboard.

Backend:
- 4 new Sort models for owner_name, nest_name, egg_name, node_name
- filterOptions endpoint returning distinct owners/nests/eggs/nodes
- Wider allowed filters and sort fields

Frontend:
- SortDropdown with field selection and direction toggle
- FilterDropdown with multi-category submenus
- Debounced search input wired to SWR
- DashboardContainer integration with sort/filter/search/view modes

Testing:
- 7 new integration tests for sort (asc/desc), entity filtering, combined sort+filter, filter-options endpoint

Cleanup:
- Removed unused showOnlyAdmin state, dead code
- Fixed all Biome lint issues
- Removed empty constructor