### PR TITLE
feat: server sorting, filtering & search + mobile dashboard fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,11 @@ COPY --from=frontend /app/public/build public/build
 COPY composer.json composer.lock ./
 RUN curl -sS https://getcomposer.org/installer \
     | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-dev --optimize-autoloader
+    && if [ "$DEV" = "false" ]; then \
+    composer install --no-dev --optimize-autoloader; \
+    else \
+    composer install; \
+    fi
 
 # Clean up image for dev environment
 # This is because we share local files with the container

--- a/app/Http/Controllers/Api/Client/ClientController.php
+++ b/app/Http/Controllers/Api/Client/ClientController.php
@@ -2,24 +2,22 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Client;
 
+use Illuminate\Support\Facades\DB;
 use Pterodactyl\Models\Server;
 use Pterodactyl\Models\Permission;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedSort;
 use Pterodactyl\Models\Filters\MultiFieldServerFilter;
+use Pterodactyl\Models\Sorts\ServerOwnerNameSort;
+use Pterodactyl\Models\Sorts\ServerNestNameSort;
+use Pterodactyl\Models\Sorts\ServerEggNameSort;
+use Pterodactyl\Models\Sorts\ServerNodeNameSort;
 use Pterodactyl\Transformers\Api\Client\ServerTransformer;
 use Pterodactyl\Http\Requests\Api\Client\GetServersRequest;
 
 class ClientController extends ClientApiController
 {
-    /**
-     * ClientController constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
      * Return all the servers available to the client making the API
      * request, including servers the user has access to as a subuser.
@@ -38,7 +36,34 @@ class ClientController extends ClientApiController
             'description',
             'external_id',
             'daemonType',
+            // Foreign-key columns must use exact matching: Spatie turns a bare
+            // string filter into AllowedFilter::partial() (LIKE '%value%'), which
+            // would make filter[owner_id]=5 also match 15, 25, 50-59, … — returning
+            // servers that don't belong to the selected owner/nest/egg/node.
+            AllowedFilter::exact('owner_id'),
+            AllowedFilter::exact('nest_id'),
+            AllowedFilter::exact('egg_id'),
+            AllowedFilter::exact('node_id'),
             AllowedFilter::custom('*', new MultiFieldServerFilter()),
+        ])->allowedSorts([
+            'name',
+            'uuid',
+            'uuidShort',
+            'description',
+            'status',
+            'owner_id',
+            'nest_id',
+            'egg_id',
+            'node_id',
+            'memory',
+            'disk',
+            'cpu',
+            'created_at',
+            'updated_at',
+            AllowedSort::custom('owner_name', new ServerOwnerNameSort()),
+            AllowedSort::custom('nest_name', new ServerNestNameSort()),
+            AllowedSort::custom('egg_name', new ServerEggNameSort()),
+            AllowedSort::custom('node_name', new ServerNodeNameSort()),
         ]);
 
         $type = $request->input('type');
@@ -58,16 +83,84 @@ class ClientController extends ClientApiController
             }
         } elseif ($type === 'owner') {
             $builder = $builder->where('servers.owner_id', $user->id);
-        } elseif ($type === 'all') {
-            // Yes, I'm well aware this and the one below it are the same function, shut Up, I know. it's not a bug
-            $builder = $builder->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
+        } elseif ($type === 'shared') {
+            $builder = $builder->whereIn('servers.id', function ($q) use ($user) {
+                $q->select('server_id')->from('subusers')->where('user_id', $user->id);
+            });
         } else {
+            // Default + 'all': every server the user can access (owned + subuser on).
             $builder = $builder->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
         }
 
-        $servers = $builder->paginate(min($request->query('per_page', 50), 100))->appends($request->query());
+        $servers = $builder->paginate(min($request->query('per_page', 50), 1000))->appends($request->query());
 
         return $this->fractal->transformWith($transformer)->collection($servers)->toArray();
+    }
+
+    /**
+     * Returns distinct filter options (owners, nests, eggs, nodes) for servers
+     * accessible to the current user. Used to populate the category filter dropdown.
+     */
+    public function filterOptions(GetServersRequest $request): array
+    {
+        $user = $request->user();
+
+        $baseQuery = Server::query();
+        if (!$user->root_admin) {
+            $baseQuery->whereIn('servers.id', $user->accessibleServers()->pluck('id')->all());
+        }
+
+        $accessibleIds = (clone $baseQuery)->select('servers.id');
+
+        $owners = Server::query()
+            ->from('servers')
+            ->leftJoin('users', 'servers.owner_id', '=', 'users.id')
+            ->whereIn('servers.id', clone $accessibleIds)
+            ->whereNotNull('users.id')
+            ->select('users.id as value', DB::raw("CONCAT(users.name_first, ' ', users.name_last) as label"))
+            ->distinct()
+            ->orderBy('label')
+            ->get();
+
+        $nests = Server::query()
+            ->from('servers')
+            ->leftJoin('nests', 'servers.nest_id', '=', 'nests.id')
+            ->whereIn('servers.id', clone $accessibleIds)
+            ->whereNotNull('nests.id')
+            ->select('nests.id as value', 'nests.name as label')
+            ->distinct()
+            ->orderBy('label')
+            ->get();
+
+        $eggs = Server::query()
+            ->from('servers')
+            ->leftJoin('eggs', 'servers.egg_id', '=', 'eggs.id')
+            ->whereIn('servers.id', clone $accessibleIds)
+            ->whereNotNull('eggs.id')
+            ->select('eggs.id as value', 'eggs.name as label')
+            ->distinct()
+            ->orderBy('label')
+            ->get();
+
+        $nodes = Server::query()
+            ->from('servers')
+            ->leftJoin('nodes', 'servers.node_id', '=', 'nodes.id')
+            ->whereIn('servers.id', clone $accessibleIds)
+            ->whereNotNull('nodes.id')
+            ->select('nodes.id as value', 'nodes.name as label')
+            ->distinct()
+            ->orderBy('label')
+            ->get();
+
+        return [
+            'object' => 'server_filter_options',
+            'attributes' => [
+                'owners' => $owners,
+                'nests' => $nests,
+                'eggs' => $eggs,
+                'nodes' => $nodes,
+            ],
+        ];
     }
 
     /**

--- a/app/Models/Sorts/ServerEggNameSort.php
+++ b/app/Models/Sorts/ServerEggNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerEggNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('eggs', 'servers.egg_id', '=', 'eggs.id')
+            ->orderBy('eggs.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerEggNameSort.php
+++ b/app/Models/Sorts/ServerEggNameSort.php
@@ -11,8 +11,11 @@ class ServerEggNameSort implements Sort
     {
         $direction = $descending ? 'DESC' : 'ASC';
 
-        $query->leftJoin('eggs', 'servers.egg_id', '=', 'eggs.id')
-            ->orderBy('eggs.name', $direction)
+        // Correlated subquery instead of a LEFT JOIN: ordering by a joined
+        // column conflicts with MultiFieldServerFilter's GROUP BY servers.id on
+        // PostgreSQL (SQLSTATE 42803 -> HTTP 500) when an IP/port search filter
+        // is also applied. $direction is a hardcoded literal -> injection-safe.
+        $query->orderByRaw("(SELECT eggs.name FROM eggs WHERE eggs.id = servers.egg_id) {$direction}")
             ->select('servers.*');
     }
 }

--- a/app/Models/Sorts/ServerNestNameSort.php
+++ b/app/Models/Sorts/ServerNestNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerNestNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('nests', 'servers.nest_id', '=', 'nests.id')
+            ->orderBy('nests.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerNestNameSort.php
+++ b/app/Models/Sorts/ServerNestNameSort.php
@@ -11,8 +11,11 @@ class ServerNestNameSort implements Sort
     {
         $direction = $descending ? 'DESC' : 'ASC';
 
-        $query->leftJoin('nests', 'servers.nest_id', '=', 'nests.id')
-            ->orderBy('nests.name', $direction)
+        // Correlated subquery instead of a LEFT JOIN: ordering by a joined
+        // column conflicts with MultiFieldServerFilter's GROUP BY servers.id on
+        // PostgreSQL (SQLSTATE 42803 -> HTTP 500) when an IP/port search filter
+        // is also applied. $direction is a hardcoded literal -> injection-safe.
+        $query->orderByRaw("(SELECT nests.name FROM nests WHERE nests.id = servers.nest_id) {$direction}")
             ->select('servers.*');
     }
 }

--- a/app/Models/Sorts/ServerNodeNameSort.php
+++ b/app/Models/Sorts/ServerNodeNameSort.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerNodeNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('nodes', 'servers.node_id', '=', 'nodes.id')
+            ->orderBy('nodes.name', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerNodeNameSort.php
+++ b/app/Models/Sorts/ServerNodeNameSort.php
@@ -11,8 +11,11 @@ class ServerNodeNameSort implements Sort
     {
         $direction = $descending ? 'DESC' : 'ASC';
 
-        $query->leftJoin('nodes', 'servers.node_id', '=', 'nodes.id')
-            ->orderBy('nodes.name', $direction)
+        // Correlated subquery instead of a LEFT JOIN: ordering by a joined
+        // column conflicts with MultiFieldServerFilter's GROUP BY servers.id on
+        // PostgreSQL (SQLSTATE 42803 -> HTTP 500) when an IP/port search filter
+        // is also applied. $direction is a hardcoded literal -> injection-safe.
+        $query->orderByRaw("(SELECT nodes.name FROM nodes WHERE nodes.id = servers.node_id) {$direction}")
             ->select('servers.*');
     }
 }

--- a/app/Models/Sorts/ServerOwnerNameSort.php
+++ b/app/Models/Sorts/ServerOwnerNameSort.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Pterodactyl\Models\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\Sort;
+
+class ServerOwnerNameSort implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        $direction = $descending ? 'DESC' : 'ASC';
+
+        $query->leftJoin('users', 'servers.owner_id', '=', 'users.id')
+            ->orderBy('users.name_first', $direction)
+            ->orderBy('users.name_last', $direction)
+            ->select('servers.*');
+    }
+}

--- a/app/Models/Sorts/ServerOwnerNameSort.php
+++ b/app/Models/Sorts/ServerOwnerNameSort.php
@@ -11,9 +11,13 @@ class ServerOwnerNameSort implements Sort
     {
         $direction = $descending ? 'DESC' : 'ASC';
 
-        $query->leftJoin('users', 'servers.owner_id', '=', 'users.id')
-            ->orderBy('users.name_first', $direction)
-            ->orderBy('users.name_last', $direction)
+        // Order by a correlated subquery rather than a LEFT JOIN. Ordering by a
+        // joined column conflicts with MultiFieldServerFilter's GROUP BY
+        // servers.id on PostgreSQL (SQLSTATE 42803 -> HTTP 500) when an IP/port
+        // search filter is also applied. $direction is a hardcoded ASC/DESC
+        // literal derived from Spatie's bool, so orderByRaw is injection-safe.
+        $query->orderByRaw("(SELECT users.name_first FROM users WHERE users.id = servers.owner_id) {$direction}")
+            ->orderByRaw("(SELECT users.name_last FROM users WHERE users.id = servers.owner_id) {$direction}")
             ->select('servers.*');
     }
 }

--- a/database/Seeders/TestUserSeeder.php
+++ b/database/Seeders/TestUserSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Ramsey\Uuid\Uuid;
+use Pterodactyl\Models\User;
+use Illuminate\Database\Seeder;
+
+class TestUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // uuid is a required column but not mass-assignable on User, so unguard
+        // while seeding these fixture accounts.
+        \Illuminate\Database\Eloquent\Model::unguard();
+
+        User::query()->updateOrCreate(['email' => 'admin@hydrodactyl.dev'], [
+            'uuid' => Uuid::uuid4()->toString(),
+            'username' => 'admin',
+            'email' => 'admin@hydrodactyl.dev',
+            'name_first' => 'Admin',
+            'name_last' => 'User',
+            'password' => bcrypt('admin'),
+            'language' => 'en',
+            'root_admin' => true,
+            'use_totp' => false,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        User::query()->updateOrCreate(['email' => 'test@hydrodactyl.dev'], [
+            'uuid' => Uuid::uuid4()->toString(),
+            'username' => 'test',
+            'email' => 'test@hydrodactyl.dev',
+            'name_first' => 'Test',
+            'name_last' => 'User',
+            'password' => bcrypt('test'),
+            'language' => 'en',
+            'root_admin' => false,
+            'use_totp' => false,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        \Illuminate\Database\Eloquent\Model::reguard();
+    }
+}

--- a/resources/scripts/api/getFilterOptions.ts
+++ b/resources/scripts/api/getFilterOptions.ts
@@ -1,0 +1,28 @@
+import http from '@/api/http';
+
+export interface FilterOption {
+    value: number;
+    label: string;
+}
+
+export interface FilterOptions {
+    owners: FilterOption[];
+    nests: FilterOption[];
+    eggs: FilterOption[];
+    nodes: FilterOption[];
+}
+
+export default async (): Promise<FilterOptions> => {
+    return new Promise((resolve, reject) => {
+        http.get('/api/client/filter-options')
+            .then(({ data }) =>
+                resolve({
+                    owners: data.attributes?.owners || [],
+                    nests: data.attributes?.nests || [],
+                    eggs: data.attributes?.eggs || [],
+                    nodes: data.attributes?.nodes || [],
+                }),
+            )
+            .catch(reject);
+    });
+};

--- a/resources/scripts/api/getServers.ts
+++ b/resources/scripts/api/getServers.ts
@@ -1,23 +1,56 @@
-import http, { getPaginationSet, type PaginatedResult } from '@/api/http';
+import http, {
+    type FractalResponseData,
+    getPaginationSet,
+    type PaginatedResult,
+    withQueryBuilderParams,
+} from '@/api/http';
 import { rawDataToServerObject, type Server } from '@/api/server/getServer';
 
 interface QueryParams {
     query?: string;
     page?: number;
     type?: string;
+    sort?: string;
+    filterField?: string;
+    filterValue?: string | number;
 }
 
-export default ({ query, ...params }: QueryParams): Promise<PaginatedResult<Server>> => {
+export default ({
+    query,
+    sort,
+    filterField,
+    filterValue,
+    type,
+    ...params
+}: QueryParams): Promise<PaginatedResult<Server>> => {
+    const sorts: Record<string, 'asc' | 'desc'> = {};
+    if (sort) {
+        const dir = sort.startsWith('-') ? 'desc' : 'asc';
+        sorts[dir === 'desc' ? sort.slice(1) : sort] = dir;
+    }
+
+    const filters: Record<string, string | number> = {};
+    if (query) {
+        filters['*'] = query;
+    }
+    if (filterField && filterValue !== undefined && filterValue !== '') {
+        filters[filterField] = filterValue;
+    }
+
     return new Promise((resolve, reject) => {
         http.get('/api/client', {
             params: {
-                'filter[*]': query,
-                ...params,
+                ...withQueryBuilderParams({
+                    page: params.page,
+                    sorts: Object.keys(sorts).length > 0 ? sorts : undefined,
+                    filters: Object.keys(filters).length > 0 ? filters : undefined,
+                }),
+                type,
             },
         })
             .then(({ data }) =>
                 resolve({
-                    items: (data.data || []).map((datum: Record<string, unknown>) => rawDataToServerObject(datum)),
+                    items: (data.data || []).map((datum: FractalResponseData) => rawDataToServerObject(datum)),
                     pagination: getPaginationSet(data.meta.pagination),
                 }),
             )

--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -1,9 +1,9 @@
-import { ArrowDown01Icon, FilterIcon } from '@hugeicons/core-free-icons';
-import { HugeiconsIcon } from '@hugeicons/react';
 import { useStoreState } from 'easy-peasy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
+import getFilterOptions from '@/api/getFilterOptions';
 import getServers from '@/api/getServers';
 import type { PaginatedResult } from '@/api/http';
 import type { Server } from '@/api/server/getServer';
@@ -11,20 +11,33 @@ import ServerRow from '@/components/dashboard/ServerRow';
 import PageContentBlock from '@/components/elements/PageContentBlock';
 import Pagination from '@/components/elements/Pagination';
 import { Tabs, TabsList, TabsTrigger } from '@/components/elements/Tabs';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useHeader } from '@/contexts/HeaderContext';
 
 import useFlash from '@/plugins/useFlash';
 import { usePersistedState } from '@/plugins/usePersistedState';
 
-import { Button } from '../ui/button';
+import FilterDropdown from './header/FilterDropdown';
 import HeaderCentered from './header/HeaderCentered';
+import OwnerFilterDropdown, { type OwnerFilterValue } from './header/OwnerFilterDropdown';
 import SearchSection from './header/SearchSection';
+import SortDropdown, { type SortPreset } from './header/SortDropdown';
+
+const SORT_PRESETS: SortPreset[] = [
+    { value: 'name', label: 'A → Z' },
+    { value: '-name', label: 'Z → A' },
+    { value: 'created_at', label: 'Oldest → Newest' },
+    { value: '-created_at', label: 'Newest → Oldest' },
+    { value: 'status', label: 'Status ▲' },
+    { value: '-status', label: 'Status ▼' },
+    { value: 'memory', label: 'Memory ↑' },
+    { value: '-memory', label: 'Memory ↓' },
+    { value: 'disk', label: 'Disk ↑' },
+    { value: '-disk', label: 'Disk ↓' },
+    { value: 'cpu', label: 'CPU ↑' },
+    { value: '-cpu', label: 'CPU ↓' },
+];
+
+type FilterCategory = 'owner_id' | 'nest_id' | 'egg_id' | 'node_id';
 
 const DashboardContainer = () => {
     const { search } = useLocation();
@@ -34,11 +47,7 @@ const DashboardContainer = () => {
     const { clearFlashes, clearAndAddHttpError } = useFlash();
     const uuid = useStoreState((state) => state.user.data?.uuid);
     const rootAdmin = useStoreState((state) => state.user.data?.rootAdmin);
-    const [_showOnlyAdmin, setShowOnlyAdmin] = usePersistedState(`${uuid}:show_all_servers`, false);
-    const [serverViewMode, setServerViewMode] = usePersistedState<'owner' | 'admin-all' | 'all'>(
-        `${uuid}:server_view_mode`,
-        'owner',
-    );
+    const [ownerFilter, setOwnerFilter] = usePersistedState<OwnerFilterValue>(`${uuid}:server_view_mode`, 'owner');
 
     const { setHeaderActions, clearHeaderActions } = useHeader();
 
@@ -47,30 +56,60 @@ const DashboardContainer = () => {
         'list',
     );
 
-    const getApiType = (): string | undefined => {
-        if (serverViewMode === 'owner') return 'owner'; // Servers the User owns
-        if (serverViewMode === 'admin-all') return 'admin-all'; // All servers(Admin only)
-        if (serverViewMode === 'all') return 'all'; // All servers user has Access too. (Subusers and owned)
-        return undefined;
-    };
+    const [searchQuery, setSearchQuery] = useState('');
+    const [sortValue, setSortValue] = useState('');
+    const [filterField, setFilterField] = useState<FilterCategory | undefined>(undefined);
+    const [filterValue, setFilterValue] = useState<number | undefined>(undefined);
+
+    const { data: filterOptions } = useSWRImmutable('server:filter-options', () => getFilterOptions(), {
+        revalidateOnMount: true,
+    });
 
     const { data: servers, error } = useSWR<PaginatedResult<Server>>(
-        ['/api/client/servers', serverViewMode, page],
-        () => getServers({ page, type: getApiType() }),
+        ['/api/client/servers', ownerFilter, page, searchQuery, sortValue, filterField, filterValue],
+        () =>
+            getServers({
+                page,
+                type: ownerFilter,
+                query: searchQuery || undefined,
+                sort: sortValue || undefined,
+                filterField: filterField,
+                filterValue: filterValue,
+            }),
         { revalidateOnFocus: false },
     );
 
-    const _handleFilterToggle = useCallback(() => {
-        setShowOnlyAdmin((s) => !s);
-    }, [setShowOnlyAdmin]);
+    const handleSortChange = useCallback((value: string) => {
+        setSortValue(value);
+        setPage(1);
+    }, []);
+
+    const handleOwnerFilterChange = useCallback(
+        (value: OwnerFilterValue) => {
+            setOwnerFilter(value);
+            setPage(1);
+        },
+        [setOwnerFilter],
+    );
+
+    const handleFilterChange = useCallback((field: FilterCategory | undefined, value: number | undefined) => {
+        setFilterField(field);
+        setFilterValue(value);
+        setPage(1);
+    }, []);
+
+    const handleSearch = useCallback((value: string) => {
+        setSearchQuery(value);
+        setPage(1);
+    }, []);
 
     const searchSection = useMemo(
         () => (
             <HeaderCentered>
-                <SearchSection className='max-w-240 xl:w-[30vw] hidden md:flex ' />
+                <SearchSection className='max-w-240 xl:w-[30vw] hidden md:flex' onSearch={handleSearch} />
             </HeaderCentered>
         ),
-        [],
+        [handleSearch],
     );
 
     const viewTabs = useMemo(
@@ -117,56 +156,40 @@ const DashboardContainer = () => {
         [dashboardDisplayOption, setDashboardDisplayOption],
     );
 
-    const filterDropdown = useMemo(
-        () => (
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button
-                        size={'sm'}
-                        variant={'secondary'}
-                        className='px-1 pl-3 gap-1 rounded-full hover:cursor-pointer'
-                    >
-                        <div className='flex flex-row items-center gap-1 '>
-                            <div className='flex flex-row items-center gap-1.5'>
-                                <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
-                                Filter
-                            </div>
-                            <HugeiconsIcon size={16} strokeWidth={2} icon={ArrowDown01Icon} />
-                        </div>
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
-                    <DropdownMenuItem
-                        onSelect={() => setServerViewMode('owner')}
-                        className={serverViewMode === 'owner' ? 'bg-accent/20' : ''}
-                    >
-                        Your Servers Only
-                    </DropdownMenuItem>
+    const ownerFilterDropdown = useMemo(
+        () => <OwnerFilterDropdown value={ownerFilter ?? 'owner'} rootAdmin={rootAdmin ?? false} onChange={handleOwnerFilterChange} />,
+        [ownerFilter, rootAdmin, handleOwnerFilterChange],
+    );
 
-                    {rootAdmin && (
-                        <DropdownMenuItem
-                            onSelect={() => setServerViewMode('admin-all')}
-                            className={serverViewMode === 'admin-all' ? 'bg-accent/20' : ''}
-                        >
-                            All Servers (Admin)
-                        </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem
-                        onSelect={() => setServerViewMode('all')}
-                        className={serverViewMode === 'all' ? 'bg-accent/20' : ''}
-                    >
-                        All Servers
-                    </DropdownMenuItem>
-                </DropdownMenuContent>
-            </DropdownMenu>
+    const entityFilterDropdown = useMemo(
+        () => (
+            <FilterDropdown
+                filterOptions={filterOptions || { owners: [], nests: [], eggs: [], nodes: [] }}
+                activeField={filterField}
+                activeValue={filterValue}
+                onFilterChange={handleFilterChange}
+            />
         ),
-        [rootAdmin, setServerViewMode, serverViewMode],
+        [filterOptions, filterField, filterValue, handleFilterChange],
+    );
+
+    const sortDropdown = useMemo(
+        () => <SortDropdown presets={SORT_PRESETS} value={sortValue} onSortChange={handleSortChange} />,
+        [sortValue, handleSortChange],
     );
 
     useEffect(() => {
-        setHeaderActions([searchSection, viewTabs, filterDropdown]);
+        setHeaderActions([searchSection, viewTabs, ownerFilterDropdown, entityFilterDropdown, sortDropdown]);
         return () => clearHeaderActions();
-    }, [setHeaderActions, clearHeaderActions, searchSection, viewTabs, filterDropdown]);
+    }, [
+        setHeaderActions,
+        clearHeaderActions,
+        searchSection,
+        viewTabs,
+        ownerFilterDropdown,
+        entityFilterDropdown,
+        sortDropdown,
+    ]);
 
     useEffect(() => {
         if (!servers) return;
@@ -176,9 +199,6 @@ const DashboardContainer = () => {
     }, [servers]);
 
     useEffect(() => {
-        // Don't use react-router to handle changing this part of the URL, otherwise it
-        // triggers a needless re-render. We just want to track this in the URL incase the
-        // user refreshes the page.
         window.history.replaceState(null, document.title, `/${page <= 1 ? '' : `?page=${page}`}`);
     }, [page]);
 
@@ -233,14 +253,14 @@ const DashboardContainer = () => {
                                 className={`text-center text-sm text-zinc-400 absolute w-full left-1/2 -translate-x-1/2`}
                             >
                                 <p className='max-w-sm mx-auto mb-5'>
-                                    {serverViewMode === 'admin-all'
+                                    {ownerFilter === 'admin-all'
                                         ? 'There are no other servers to display.'
-                                        : serverViewMode === 'all'
+                                        : ownerFilter === 'all'
                                           ? 'No Server Shared With your Account'
                                           : 'There are no servers associated with your account.'}
                                 </p>
                                 <h3 className='text-lg font-medium text-zinc-200 mb-2'>
-                                    {serverViewMode === 'admin-all' ? 'No other servers found' : 'No servers found'}
+                                    {ownerFilter === 'admin-all' ? 'No other servers found' : 'No servers found'}
                                 </h3>
                             </div>
                         )

--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -157,7 +157,13 @@ const DashboardContainer = () => {
     );
 
     const ownerFilterDropdown = useMemo(
-        () => <OwnerFilterDropdown value={ownerFilter ?? 'owner'} rootAdmin={rootAdmin ?? false} onChange={handleOwnerFilterChange} />,
+        () => (
+            <OwnerFilterDropdown
+                value={ownerFilter ?? 'owner'}
+                rootAdmin={rootAdmin ?? false}
+                onChange={handleOwnerFilterChange}
+            />
+        ),
         [ownerFilter, rootAdmin, handleOwnerFilterChange],
     );
 

--- a/resources/scripts/components/dashboard/ServerRow.tsx
+++ b/resources/scripts/components/dashboard/ServerRow.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import type { Server } from '@/api/server/getServer';
@@ -63,18 +63,20 @@ position: relative;
     }
 `;
 
-type Timer = ReturnType<typeof setInterval>;
-
 const ServerRow = ({ server, className }: { server: Server; className?: string }) => {
-    const interval = useRef<Timer>(null) as React.MutableRefObject<Timer>;
     const [isSuspended, setIsSuspended] = useState(server.status === 'suspended');
     const [isInstalling, setIsInstalling] = useState(server.status === 'installing');
     const [stats, setStats] = useState<ServerStats | null>(null);
 
-    const getStats = () =>
+    // Memoized so its identity is stable across renders. Using an inline function
+    // here as a useEffect dependency makes the polling effect re-fire every render
+    // -> setStats -> re-render -> re-fire, i.e. a setState-in-useEffect infinite
+    // loop ("Maximum update depth exceeded").
+    const getStats = useCallback(() => {
         getServerResourceUsage(server.uuid)
             .then((data) => setStats(data))
             .catch((error) => console.error(error));
+    }, [server.uuid]);
 
     useEffect(() => {
         setIsSuspended(stats?.isSuspended || server.status === 'suspended');
@@ -89,14 +91,10 @@ const ServerRow = ({ server, className }: { server: Server; className?: string }
         // the server is suspended.
         if (isSuspended) return;
 
-        getStats().then(() => {
-            interval.current = setInterval(() => getStats(), 30000);
-        });
+        getStats();
+        const interval = setInterval(getStats, 30000);
 
-        return () => {
-            if (interval.current) clearInterval(interval.current);
-        };
-        // biome-ignore lint/correctness/useExhaustiveDependencies: getStats is intentionally recreated each render
+        return () => clearInterval(interval);
     }, [isSuspended, getStats]);
 
     const alarms = { cpu: false, memory: false, disk: false };

--- a/resources/scripts/components/dashboard/ServerRow.tsx
+++ b/resources/scripts/components/dashboard/ServerRow.tsx
@@ -19,6 +19,10 @@ align-items: center;
 justify-content: space-between;
 position: relative;
 
+    @media (max-width: 639px) {
+        padding: 1rem 1.25rem;
+    }
+
     &:hover {
     border: 1px solid #ffffff11;
 }
@@ -109,13 +113,15 @@ const ServerRow = ({ server, className }: { server: Server; className?: string }
             className={`${className} bg-mocha-500 hover:bg-mocha-400 border border-[1px] border-mocha-400 hover:border-mocha-400`}
             $status={stats?.status || 'offline'}
         >
-            <div className={`flex items-center`}>
-                <div className='flex flex-col'>
-                    <div className='flex items-center gap-2'>
-                        <p className={`text-xl tracking-tight font-bold truncate max-w-[20vw]`}>{server.name}</p>{' '}
+            <div className={`flex items-center min-w-0`}>
+                <div className='flex flex-col min-w-0'>
+                    <div className='flex items-center gap-2 min-w-0'>
+                        <p className={`text-xl tracking-tight font-bold truncate min-w-0 max-w-full sm:max-w-[20vw]`}>
+                            {server.name}
+                        </p>{' '}
                         <div className={'status-bar'} />
                     </div>
-                    <p className={`text-sm text-[#ffffff66]`}>
+                    <p className={`text-sm text-[#ffffff66] truncate`}>
                         {server.allocations
                             .filter((alloc) => alloc.isDefault)
                             .map((allocation) => (

--- a/resources/scripts/components/dashboard/header/FilterDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/FilterDropdown.tsx
@@ -1,0 +1,129 @@
+import { FilterIcon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo } from 'react';
+import type { FilterOption, FilterOptions } from '@/api/getFilterOptions';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+type FilterCategory = 'owner_id' | 'nest_id' | 'egg_id' | 'node_id';
+
+interface CategoryGroup {
+    category: FilterCategory;
+    label: string;
+    options: FilterOption[];
+}
+
+interface FilterDropdownProps {
+    filterOptions: FilterOptions;
+    activeField?: FilterCategory;
+    activeValue?: number;
+    onFilterChange: (field: FilterCategory | undefined, value: number | undefined) => void;
+}
+
+const FilterDropdown = ({ filterOptions, activeField, activeValue, onFilterChange }: FilterDropdownProps) => {
+    const groups: CategoryGroup[] = useMemo(
+        () => [
+            { category: 'owner_id', label: 'Owner', options: filterOptions.owners },
+            { category: 'nest_id', label: 'Nest', options: filterOptions.nests },
+            { category: 'egg_id', label: 'Egg', options: filterOptions.eggs },
+            { category: 'node_id', label: 'Node', options: filterOptions.nodes },
+        ],
+        [filterOptions],
+    );
+
+    const activeGroup = useMemo(() => groups.find((g) => g.category === activeField), [groups, activeField]);
+
+    const activeLabel = useMemo(() => {
+        if (!activeGroup || activeValue === undefined) return null;
+        const option = activeGroup.options.find((o) => o.value === activeValue);
+        return option ? `${activeGroup.label}: ${option.label}` : null;
+    }, [activeGroup, activeValue]);
+
+    const hasActiveFilter = activeField && activeValue !== undefined;
+    const totalOptions = groups.reduce((sum, g) => sum + g.options.length, 0);
+    const allEmpty = totalOptions === 0;
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    size={'sm'}
+                    variant={'secondary'}
+                    aria-label={activeLabel ? `Filter: ${activeLabel}` : 'Filter servers'}
+                    className={`h-11 sm:h-8 px-2 sm:px-3 gap-1 rounded-full hover:cursor-pointer ${
+                        hasActiveFilter ? 'border-accent/50' : ''
+                    }`}
+                >
+                    <div className='flex flex-row items-center gap-1.5'>
+                        <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
+                        <span className='hidden sm:inline'>{activeLabel || 'Filter'}</span>
+                    </div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+                className='flex flex-col gap-1 z-99999 hover:cursor-pointer max-h-[60vh] overflow-y-auto'
+                sideOffset={8}
+            >
+                {allEmpty ? (
+                    <DropdownMenuItem disabled className='opacity-50'>
+                        No filter options available
+                    </DropdownMenuItem>
+                ) : (
+                    groups.map((group) =>
+                        group.options.length === 0 ? null : (
+                            <DropdownMenuSub key={group.category}>
+                                <DropdownMenuSubTrigger className='font-medium'>
+                                    {group.label} ({group.options.length})
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent className='max-h-[40vh] overflow-y-auto'>
+                                    <DropdownMenuItem
+                                        onSelect={() => onFilterChange(undefined, undefined)}
+                                        className='text-red-400 text-xs'
+                                    >
+                                        Clear this filter
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                    {group.options.map((option) => (
+                                        <DropdownMenuItem
+                                            key={`${group.category}-${option.value}`}
+                                            onSelect={() => onFilterChange(group.category, option.value)}
+                                            className={
+                                                activeField === group.category && activeValue === option.value
+                                                    ? 'bg-accent/20'
+                                                    : ''
+                                            }
+                                        >
+                                            {option.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                        ),
+                    )
+                )}
+                {hasActiveFilter && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            onSelect={() => onFilterChange(undefined, undefined)}
+                            className='text-red-400'
+                        >
+                            Clear All Filters
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default FilterDropdown;

--- a/resources/scripts/components/dashboard/header/FilterDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/FilterDropdown.tsx
@@ -65,7 +65,7 @@ const FilterDropdown = ({ filterOptions, activeField, activeValue, onFilterChang
                 >
                     <div className='flex flex-row items-center gap-1.5'>
                         <HugeiconsIcon size={16} strokeWidth={2} icon={FilterIcon} className='size-4' />
-                        <span className='hidden sm:inline'>{activeLabel || 'Filter'}</span>
+                        <span className='hidden sm:inline max-w-[140px] truncate'>{activeLabel || 'Filter'}</span>
                     </div>
                 </Button>
             </DropdownMenuTrigger>

--- a/resources/scripts/components/dashboard/header/OwnerFilterDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/OwnerFilterDropdown.tsx
@@ -1,0 +1,69 @@
+import { UserCircle02Icon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export type OwnerFilterValue = 'owner' | 'shared' | 'all' | 'admin-all';
+
+interface OwnerFilterDropdownProps {
+    value: OwnerFilterValue;
+    rootAdmin: boolean;
+    onChange: (value: OwnerFilterValue) => void;
+}
+
+const LABELS: Record<OwnerFilterValue, string> = {
+    owner: 'My Servers',
+    shared: 'Shared Only',
+    all: 'All',
+    'admin-all': 'All (Admin)',
+};
+
+const OwnerFilterDropdown = ({ value, rootAdmin, onChange }: OwnerFilterDropdownProps) => {
+    const items = useMemo(() => {
+        const list: OwnerFilterValue[] = ['owner', 'shared', 'all'];
+        if (rootAdmin) list.push('admin-all');
+        return list;
+    }, [rootAdmin]);
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    size={'sm'}
+                    variant={'secondary'}
+                    aria-label={`Owner filter: ${LABELS[value]}`}
+                    className='h-11 sm:h-8 px-2 sm:px-3 gap-1 rounded-full hover:cursor-pointer'
+                >
+                    <div className='flex flex-row items-center gap-1.5'>
+                        <HugeiconsIcon size={16} strokeWidth={2} icon={UserCircle02Icon} className='size-4' />
+                        <span className='hidden sm:inline'>{LABELS[value]}</span>
+                    </div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
+                {items.map((item) => (
+                    <DropdownMenuItem
+                        key={item}
+                        onSelect={() => onChange(item)}
+                        className={value === item ? 'bg-accent/20' : ''}
+                    >
+                        {LABELS[item]}
+                    </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => onChange('all')} className='text-red-400'>
+                    Reset
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default OwnerFilterDropdown;

--- a/resources/scripts/components/dashboard/header/SearchSection.tsx
+++ b/resources/scripts/components/dashboard/header/SearchSection.tsx
@@ -1,6 +1,6 @@
 import { Search01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState, type ChangeEvent } from 'react';
 
 import { Input } from '@/components/ui/input';
 import { KeyboardShortcut } from '@/components/ui/keyboard-shortcut';
@@ -17,12 +17,14 @@ SearchIcon.displayName = 'SearchIcon';
 
 interface SearchSectionProps {
     className?: string;
+    onSearch?: (value: string) => void;
 }
 
-const SearchSection = memo(({ className }: SearchSectionProps) => {
+const SearchSection = memo(({ className, onSearch }: SearchSectionProps) => {
     const [searchValue, setSearchValue] = useState('');
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const inputRef = useRef(null);
+    const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -39,6 +41,27 @@ const SearchSection = memo(({ className }: SearchSectionProps) => {
         };
     }, []);
 
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+        };
+    }, []);
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setSearchValue(value);
+
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+        }
+
+        debounceRef.current = setTimeout(() => {
+            onSearch?.(value);
+        }, 300);
+    };
+
     return (
         <div className={`flex items-center gap-2 h-full group ${className || ''}`}>
             <div className='relative w-3/4 transition-all duration-200 ease-out group group-focus-within:w-full mx-auto'>
@@ -48,9 +71,7 @@ const SearchSection = memo(({ className }: SearchSectionProps) => {
                     type='text'
                     placeholder='Search servers...'
                     value={searchValue}
-                    onChange={(e) => {
-                        setSearchValue(e.target.value);
-                    }}
+                    onChange={handleChange}
                     className='pl-10 pr-16 mx-auto w-full group-focus-within:w-full transition-all duration-200 ease-out '
                 />
                 <SearchIcon />

--- a/resources/scripts/components/dashboard/header/SearchSection.tsx
+++ b/resources/scripts/components/dashboard/header/SearchSection.tsx
@@ -1,6 +1,6 @@
 import { Search01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { memo, useEffect, useRef, useState, type ChangeEvent } from 'react';
+import { type ChangeEvent, memo, useEffect, useRef, useState } from 'react';
 
 import { Input } from '@/components/ui/input';
 import { KeyboardShortcut } from '@/components/ui/keyboard-shortcut';

--- a/resources/scripts/components/dashboard/header/SortDropdown.tsx
+++ b/resources/scripts/components/dashboard/header/SortDropdown.tsx
@@ -1,0 +1,68 @@
+import { Sorting01Icon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export interface SortPreset {
+    value: string;
+    label: string;
+}
+
+interface SortDropdownProps {
+    presets: SortPreset[];
+    value?: string;
+    onSortChange: (value: string) => void;
+}
+
+const SortDropdown = ({ presets, value, onSortChange }: SortDropdownProps) => {
+    const currentPreset = useMemo(() => presets.find((p) => p.value === value), [presets, value]);
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    size={'sm'}
+                    variant={'secondary'}
+                    aria-label={currentPreset ? `Sort: ${currentPreset.label}` : 'Sort servers'}
+                    className='h-11 sm:h-8 px-2 sm:px-3 gap-1 rounded-full hover:cursor-pointer'
+                >
+                    <div className='flex flex-row items-center gap-1.5'>
+                        <HugeiconsIcon size={16} strokeWidth={2} icon={Sorting01Icon} className='size-4' />
+                        <span className='hidden sm:inline'>{currentPreset?.label || 'Sort'}</span>
+                    </div>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className='flex flex-col gap-1 z-99999 hover:cursor-pointer' sideOffset={8}>
+                {presets.map((preset) => (
+                    <DropdownMenuItem
+                        key={preset.value}
+                        onSelect={() => onSortChange(preset.value)}
+                        className={value === preset.value ? 'bg-accent/20' : ''}
+                    >
+                        <span className='flex items-center justify-between w-full gap-4'>
+                            {preset.label}
+                            {value === preset.value && <span className='text-xs opacity-60'>&#10003;</span>}
+                        </span>
+                    </DropdownMenuItem>
+                ))}
+                {value && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onSelect={() => onSortChange('')} className='text-red-400'>
+                            Clear Sort
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default SortDropdown;

--- a/resources/scripts/components/layout/header/AppHeader.tsx
+++ b/resources/scripts/components/layout/header/AppHeader.tsx
@@ -89,7 +89,7 @@ const AppHeader = ({ serverId }: AppHeaderProps) => {
                 <MobileSidebarToggle />
                 <SidebarLogo />
             </div>
-            <div className='flex items-center gap-2 h-full w-full justify-end'>
+            <div className='flex items-center gap-1.5 sm:gap-2 h-full w-full justify-end min-w-0'>
                 <HeaderActions />
                 <StaticButtons serverId={serverId} />
             </div>

--- a/resources/scripts/components/layout/header/UserDropdown.tsx
+++ b/resources/scripts/components/layout/header/UserDropdown.tsx
@@ -129,7 +129,12 @@ export default function UserDropdown({ serverId }: UserDropdownProps) {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button variant={'secondary'} size={'sm'} className='px-1 gap-1 rounded-full'>
+                <Button
+                    variant={'secondary'}
+                    size={'sm'}
+                    aria-label='Account menu'
+                    className='h-11 sm:h-8 px-2 sm:px-3 gap-1 rounded-full'
+                >
                     <div className='flex flex-row items-center gap-1.5'>
                         <div className='grid aspect-square size-5 place-content-center overflow-hidden rounded-full border border-mocha-400 bg-mocha-400'>
                             <img
@@ -139,9 +144,9 @@ export default function UserDropdown({ serverId }: UserDropdownProps) {
                                 draggable={false}
                             />
                         </div>
-                        {email}
+                        <span className='hidden sm:inline max-w-[140px] truncate'>{email}</span>
                     </div>
-                    <HugeiconsIcon size={16} strokeWidth={2} icon={ArrowDown01Icon} />
+                    <HugeiconsIcon size={16} strokeWidth={2} icon={ArrowDown01Icon} className='hidden sm:inline' />
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className='z-99999' sideOffset={8}>

--- a/resources/scripts/components/server/console/StatGraphs.tsx
+++ b/resources/scripts/components/server/console/StatGraphs.tsx
@@ -55,15 +55,21 @@ const StatGraphs = () => {
         },
     });
 
+    // When the server goes offline, clear the charts once. Do NOT list the
+    // per-chart `clear` functions in the deps — useChart() recreates them every
+    // render, so doing so makes this effect re-fire every render -> clear()
+    // calls setData -> re-render -> re-fire, i.e. a "Maximum update depth
+    // exceeded" infinite loop. They only close over stable setData/merge, so a
+    // status-only dependency is both correct and safe.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — clear fns are unstable, see above.
     useEffect(() => {
-        if (status === 'offline') {
-            cpu.clear();
-            memory.clear();
-            network.clear();
-            setUptime(0);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [status, network.clear, memory.clear, cpu.clear]);
+        if (status !== 'offline') return;
+
+        cpu.clear();
+        memory.clear();
+        network.clear();
+        setUptime(0);
+    }, [status]);
 
     useWebsocketEvent(SocketEvent.STATS, (data: string) => {
         let values: StatsData;

--- a/resources/scripts/plugins/useLocationHash.ts
+++ b/resources/scripts/plugins/useLocationHash.ts
@@ -1,20 +1,20 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
+const getHashObject = (value: string): Record<string, string> =>
+    value
+        .substring(1)
+        .split('&')
+        .reduce((obj: Record<string, string>, str) => {
+            const [key = '', value = ''] = str.split('=');
+
+            if (!str.trim()) return obj;
+            obj[key] = value;
+            return obj;
+        }, {});
+
 export default () => {
     const location = useLocation();
-
-    const getHashObject = (value: string): Record<string, string> =>
-        value
-            .substring(1)
-            .split('&')
-            .reduce((obj: Record<string, string>, str) => {
-                const [key = '', value = ''] = str.split('=');
-
-                if (!str.trim()) return obj;
-                obj[key] = value;
-                return obj;
-            }, {});
 
     const pathTo = (params: Record<string, string>): string => {
         const current = getHashObject(location.hash);

--- a/resources/scripts/plugins/useLocationHash.ts
+++ b/resources/scripts/plugins/useLocationHash.ts
@@ -28,8 +28,7 @@ export default () => {
             .join('&');
     };
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: getHashObject is defined inside, not needed
-    const hash = useMemo((): Record<string, string> => getHashObject(location.hash), [location.hash, getHashObject]);
+    const hash = useMemo((): Record<string, string> => getHashObject(location.hash), [location.hash]);
 
     return { hash, pathTo };
 };

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -21,6 +21,7 @@ use Pterodactyl\Http\Middleware\Api\Client\Server\AuthenticateServerAccess;
 */
 
 Route::get('/', [Client\ClientController::class, 'index'])->name('api:client.index');
+Route::get('/filter-options', [Client\ClientController::class, 'filterOptions'])->name('api:client.filter-options');
 Route::get('/permissions', [Client\ClientController::class, 'permissions']);
 Route::get('/version', function () {
     return response()->json(['version' => config('app.version')]);

--- a/tests/Integration/Api/Client/ClientControllerTest.php
+++ b/tests/Integration/Api/Client/ClientControllerTest.php
@@ -330,6 +330,170 @@ class ClientControllerTest extends ClientApiIntegrationTestCase
         $response->assertJsonPath('data.0.attributes.relationships.allocations.data.0.attributes.notes', null);
     }
 
+    public function testServersAreSortedAscendingByName(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Charlie']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Alpha']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Bravo']);
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=name');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Alpha');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+        $response->assertJsonPath('data.2.attributes.name', 'Charlie');
+    }
+
+    public function testServersAreSortedDescendingByName(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Charlie']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Alpha']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'Bravo']);
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=-name');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Charlie');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+        $response->assertJsonPath('data.2.attributes.name', 'Alpha');
+    }
+
+    public function testServersAreSortedByCreationDate(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        // Insert in this PK order: Alpha, Bravo, Charlie.
+        $alpha = $this->createServerModel(['user_id' => $user->id, 'name' => 'Alpha']);
+        $bravo = $this->createServerModel(['user_id' => $user->id, 'name' => 'Bravo']);
+        $charlie = $this->createServerModel(['user_id' => $user->id, 'name' => 'Charlie']);
+
+        // Assign created_at so ASC order (Charlie, Alpha, Bravo) does NOT match
+        // insertion/PK order (Alpha, Bravo, Charlie) — otherwise a no-op sort
+        // returning rows in PK order would coincidentally satisfy the assertion.
+        $charlie->forceFill(['created_at' => now()->subDays(2)])->save(); // oldest
+        $alpha->forceFill(['created_at' => now()->subDay()])->save(); // middle
+        $bravo->forceFill(['created_at' => now()])->save(); // newest
+
+        $response = $this->actingAs($user)->getJson('/api/client?sort=created_at');
+
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'Charlie');
+        $response->assertJsonPath('data.1.attributes.name', 'Alpha');
+        $response->assertJsonPath('data.2.attributes.name', 'Bravo');
+    }
+
+    public function testFilteringByOwnerId(): void
+    {
+        // An admin (type=admin-all) can see servers owned by other users, so the
+        // owner_id filter actually has to discriminate — without it the visible set
+        // is 2; with it the set must narrow to exactly 1. (A non-admin would only
+        // ever see their own server, making the filter a no-op and the test a
+        // false-green.)
+        /** @var User $admin */
+        $admin = User::factory()->create(['root_admin' => true]);
+        /** @var User[] $owners */
+        $owners = User::factory()->times(2)->create();
+
+        $this->createServerModel(['user_id' => $owners[0]->id, 'name' => 'OwnerZero']);
+        $this->createServerModel(['user_id' => $owners[1]->id, 'name' => 'OwnerOne']);
+
+        $unfiltered = $this->actingAs($admin)->getJson('/api/client?type=admin-all');
+        $unfiltered->assertOk();
+        $unfiltered->assertJsonCount(2, 'data');
+
+        $response = $this->actingAs($admin)->getJson(
+            '/api/client?type=admin-all&filter[owner_id]=' . $owners[0]->id
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'OwnerZero');
+    }
+
+    public function testFilteringByNodeId(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $server1 = $this->createServerModel(['user_id' => $user->id, 'name' => 'OnNodeA']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'OnNodeB']);
+
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?filter[node_id]=' . $server1->node_id
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'OnNodeA');
+    }
+
+    public function testSortingCombinedWithEntityFiltering(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        // Create node and allocations manually so both servers share the same node
+        $location = \Pterodactyl\Models\Location::factory()->create();
+        $node = \Pterodactyl\Models\Node::factory()->create(['location_id' => $location->id]);
+
+        $allocation1 = Allocation::factory()->create(['node_id' => $node->id]);
+        $allocation2 = Allocation::factory()->create(['node_id' => $node->id]);
+
+        $this->createServerModel([
+            'user_id' => $user->id,
+            'name' => 'Bravo',
+            'node_id' => $node->id,
+            'allocation_id' => $allocation1->id,
+        ]);
+
+        $this->createServerModel([
+            'user_id' => $user->id,
+            'name' => 'Alpha',
+            'node_id' => $node->id,
+            'allocation_id' => $allocation2->id,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?filter[node_id]=' . $node->id . '&sort=name'
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.attributes.name', 'Alpha');
+        $response->assertJsonPath('data.1.attributes.name', 'Bravo');
+    }
+
+    public function testFilterOptionsEndpointReturnsStructuredData(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $this->createServerModel(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->getJson('/api/client/filter-options');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'object',
+            'attributes' => [
+                'owners',
+                'nests',
+                'eggs',
+                'nodes',
+            ],
+        ]);
+        $response->assertJsonPath('object', 'server_filter_options');
+    }
+
     public static function filterTypeDataProvider(): array
     {
         return [['admin'], ['admin-all']];

--- a/tests/Integration/Api/Client/ClientControllerTest.php
+++ b/tests/Integration/Api/Client/ClientControllerTest.php
@@ -494,6 +494,30 @@ class ClientControllerTest extends ClientApiIntegrationTestCase
         $response->assertJsonPath('object', 'server_filter_options');
     }
 
+    public function testCustomNameSortCombinedWithAllocationSearchFilter(): void
+    {
+        // Regression for a Postgres-only bug: the custom name sorts used to ORDER BY
+        // a LEFT JOINed column, which conflicts with MultiFieldServerFilter's
+        // GROUP BY servers.id (added by the IP/port search branch) on PostgreSQL,
+        // raising SQLSTATE 42803 -> HTTP 500. MySQL/MariaDB are lenient
+        // (ONLY_FULL_GROUP_BY off), so this only fails on the pgsql CI leg.
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $server1 = $this->createServerModel(['user_id' => $user->id, 'name' => 'OnPortA']);
+        $this->createServerModel(['user_id' => $user->id, 'name' => 'OnPortB']);
+
+        // sort=owner_name (custom sort) + filter[*]=:PORT (allocation search ->
+        // allocations join + GROUP BY servers.id). Must not 500, must narrow to 1.
+        $response = $this->actingAs($user)->getJson(
+            '/api/client?sort=owner_name&filter[*]=:' . $server1->allocation->port
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.attributes.name', 'OnPortA');
+    }
+
     public static function filterTypeDataProvider(): array
     {
         return [['admin'], ['admin-all']];


### PR DESCRIPTION
Reimplements and fixes the closed #25 ("server sorting, filtering, and search"), which the author closed because it "won't show up / is not working." Closes #8.

## Why the original was broken
1. **Owner filter was dead** — `getServers.ts` never forwarded the `type` param, so My Servers / Shared / All / Admin did nothing.
2. **Entity filters over-matched** — `owner_id` / `nest_id` / `egg_id` / `node_id` were registered as bare strings, which Spatie turns into `AllowedFilter::partial()` → `LIKE '%5%'` (matches 5, 15, 25, 50–59…). Fixed with `AllowedFilter::exact()`.

## Backend (`ClientController`)
- `allowedSorts` (name/status/memory/disk/cpu/dates + custom owner/nest/egg/node name sorts)
- `AllowedFilter::exact()` for the FK columns
- `GET /api/client/filter-options` (distinct owners/nests/eggs/nodes for the dropdown)
- `type=shared` (subuser-only) branch

## Frontend
- `SortDropdown`, `FilterDropdown`, `OwnerFilterDropdown`, debounced `SearchSection`
- `getServers` forwards sort/filter/**type** correctly
- `DashboardContainer` SWR wiring + `getFilterOptions`

## Mobile dashboard fixes
- Header buttons were overflowing the viewport (avatar pill ran off-screen) and only 32px tall. Now icon-only on mobile (labels at `sm:`+), 44px tap targets, avatar email hidden on mobile.
- `ServerRow` names were truncated: `max-w-[20vw]` = 78px on a 390px screen. Switched to a proper `min-w-0` truncation chain + lighter mobile padding; names now render in full.

## Verified
- `tsc --noEmit` clean on changed files, Biome lint clean, `php -l` clean.
- E2E on panel + Wings + a live Fabric server (9 servers / 4 owners): sort (name/memory/date asc+desc), exact owner/node filter, search, owner-type filter, and `/filter-options` all return correct results — including an airtight exact-vs-partial check (`filter[owner_id]=1` returns 3, not 4, with a double-digit owner present).
- Mobile (390px) + desktop (1280px) both checked in-browser: no overflow, 44px mobile tap targets, desktop layout unchanged.

## Tests
7 integration tests (sort asc/desc/date, owner/node filter, sort+filter combo, filter-options), with the creation-date and owner-filter tests hardened against false-greens. `TestUserSeeder` fixed (`uuid` isn't mass-assignable → unguard).