### PR TITLE
fix: infinite captcha widget re-render on auth pages

### DIFF
--- a/resources/scripts/components/elements/Captcha.tsx
+++ b/resources/scripts/components/elements/Captcha.tsx
@@ -20,7 +20,7 @@ export default function Captcha({
     size = 'flexible',
 }: CaptchaProps) {
     const containerRef = useRef<HTMLDivElement>(null);
-    const [widgetId, setWidgetId] = useState<string | null>(null);
+    const widgetIdRef = useRef<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -62,9 +62,9 @@ export default function Captcha({
             if (!containerRef.current) return;
 
             // Clean up any existing widget first
-            if (widgetId) {
+            if (widgetIdRef.current) {
                 CaptchaManager.removeWidget();
-                setWidgetId(null);
+                widgetIdRef.current = null;
             }
 
             // Clear the container
@@ -91,7 +91,7 @@ export default function Captcha({
                 });
 
                 if (mounted) {
-                    setWidgetId(id);
+                    widgetIdRef.current = id;
                 }
             } catch (_err) {
                 if (mounted) {
@@ -108,12 +108,13 @@ export default function Captcha({
 
         return () => {
             mounted = false;
-            if (widgetId) {
+            if (widgetIdRef.current) {
                 CaptchaManager.removeWidget();
+                widgetIdRef.current = null;
             }
         };
-        // biome-ignore lint/correctness/useExhaustiveDependencies: callbacks use refs so they are stable
-    }, [theme, size, widgetId, handleSuccess, handleExpired, handleError]);
+        // biome-ignore lint/correctness/useExhaustiveDependencies: handlers delegate through refs so they are stable
+    }, [theme, size]);
 
     // Set up event listeners for captcha events
     useEffect(() => {


### PR DESCRIPTION
# Login page freezes browser (100% CPU) when any captcha provider is enabled

## Summary

With a captcha provider enabled (tested with Turnstile), the login page pegs the CPU
at 100% and freezes the tab. On mobile the tab crashes and auto-reloads in a loop.
With `captcha:provider` set to `none` the page behaves normally.

## Root cause

`resources/scripts/components/elements/Captcha.tsx` has an infinite re-render loop
in its main `useEffect`:

```ts
useEffect(() => {
    ...
    const initializeCaptcha = async () => {
        ...
        if (widgetId) {
            CaptchaManager.removeWidget();
            setWidgetId(null);          // <- state change re-triggers this effect
        }
        ...
        const id = await CaptchaManager.renderWidget(...);
        if (mounted) {
            setWidgetId(id);            // <- state change re-triggers this effect
        }
    };
    initializeCaptcha();
    ...
// biome-ignore lint/correctness/useExhaustiveDependencies: callbacks use refs so they are stable
}, [theme, size, widgetId, handleSuccess, handleExpired, handleError]);
```

Two problems with the dependency array:

1. **`widgetId` is both a dependency and set by the effect.** Effect runs →
   `setWidgetId(id)` → effect re-runs → `removeWidget()` + `setWidgetId(null)` →
   effect re-runs → renders a new widget → `setWidgetId(id)` → … forever.
2. **`handleSuccess` / `handleError` / `handleExpired` are recreated every render**
   (they are plain function declarations in the component body), so they change
   identity on every render and re-trigger the effect even without `widgetId`.
   The `biome-ignore` comment says "callbacks use refs so they are stable" — the
   *refs* are stable, but the wrapper functions listed in the deps array are not.

Each loop iteration destroys and re-creates the captcha widget (for Turnstile,
a full Cloudflare iframe + challenge), drowning the CPU.

This affects all providers (Turnstile/hCaptcha/reCAPTCHA) since they share this
component, but may go unnoticed by default because `captcha.provider` defaults
to `none`, where the component early-returns before the effect body runs.

## Suggested fix

Run the initialization effect only on mount (and when `theme`/`size` change),
track the widget id in a reference instead of state, and drop the unstable callbacks
from the deps:

See full fix in commit (0b1e6b0)

## Environment

- Version: Hydrodactyl v6.2.0 
- Captcha: Turnstile with valid site/secret keys (migrated from Pyrodactyl)
- Reproduces on desktop Chrome/Firefox and mobile browsers
- Fix in this report was verified against a live panel, with the patched
  `Captcha.tsx` deployed, the Turnstile widget renders once and login works normally.
  
 Fixes https://github.com/BlueprintFramework/hydrodactyl/issues/47
 
**Diagnosis and fix assisted by Claude, fully reviewed and verified by a human.**