### PR TITLE
feat: add self-registration with User rank and captcha support

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pterodactyl\Http\Controllers\Auth;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Container\Container;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Support\Facades\Event;
+use Pterodactyl\Facades\Activity;
+use Pterodactyl\Models\User;
+use Pterodactyl\Events\Auth\DirectLogin;
+use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Http\Requests\Auth\RegisterRequest;
+use Pterodactyl\Services\Users\UserCreationService;
+
+class RegisterController extends Controller
+{
+    protected AuthManager $auth;
+
+    public function __construct(
+        private ViewFactory $view,
+        private UserCreationService $creationService,
+    ) {
+        $this->auth = Container::getInstance()->make(AuthManager::class);
+    }
+
+    public function index(): View
+    {
+        return $this->view->make('templates/auth.core');
+    }
+
+    /**
+     * @throws \Pterodactyl\Exceptions\Model\DataValidationException
+     * @throws \Exception
+     */
+    public function register(RegisterRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+
+        /** @var User $user */
+        $user = $this->creationService->handle([
+            'email' => $data['email'],
+            'username' => $data['username'],
+            'name_first' => $data['name_first'],
+            'name_last' => $data['name_last'] ?? null,
+            'password' => $data['password'],
+        ]);
+
+        $request->session()->regenerate();
+        $this->auth->guard()->login($user, true);
+        Event::dispatch(new DirectLogin($user, true));
+
+        Activity::event('auth:register')
+            ->withRequestMetadata()
+            ->subject($user)
+            ->log('registered a new account via the self-registration flow');
+
+        return new JsonResponse([
+            'data' => [
+                'complete' => true,
+                'intended' => '/',
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pterodactyl\Http\Requests\Auth;
+
+use Pterodactyl\Rules\Username;
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorized(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email:rfc', 'between:1,191', 'unique:users,email'],
+            'username' => ['required', 'string', 'between:1,191', 'unique:users,username', new Username()],
+            'name_first' => ['required', 'string', 'between:1,191'],
+            'name_last' => ['nullable', 'string', 'between:0,191'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -77,10 +77,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function configureRateLimiting(): void
     {
-        // Authentication rate limiting. For login and checkpoint endpoints we'll apply
-        // a limit of 10 requests per minute, for the forgot password endpoint apply a
-        // limit of two per minute for the requester so that there is less ability to
-        // trigger email spam.
+        // Authentication rate limiting. For login, registration, and checkpoint
+        // endpoints we'll apply a limit of 10 requests per minute, for the forgot
+        // password endpoint apply a limit of two per minute for the requester so
+        // that there is less ability to trigger email spam.
         RateLimiter::for('authentication', function (Request $request) {
             if ($request->route()->named('auth.post.forgot-password')) {
                 return Limit::perMinute(2)->by($request->ip());

--- a/resources/scripts/api/auth/register.ts
+++ b/resources/scripts/api/auth/register.ts
@@ -1,0 +1,27 @@
+import http from '@/api/http';
+
+export interface RegisterData {
+    email: string;
+    username: string;
+    name_first: string;
+    name_last?: string;
+    password: string;
+    password_confirmation: string;
+    [key: string]: unknown;
+}
+
+export interface RegisterResponse {
+    complete: boolean;
+    intended?: string;
+}
+
+export default async (data: RegisterData): Promise<RegisterResponse> => {
+    await http.get('/sanctum/csrf-cookie');
+
+    const response = await http.post('/auth/register', data);
+
+    return {
+        complete: response.data?.data?.complete ?? response.data?.complete ?? false,
+        intended: response.data?.data?.intended ?? response.data?.intended ?? '/',
+    };
+};

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -136,6 +136,12 @@ function LoginContainer() {
                         </Button>
                         <SecondaryLink to='/auth/password'>Forgot your password?</SecondaryLink>
                     </div>
+                    <div className='flex w-full justify-center items-center mt-4'>
+                        <span className='text-secondary text-sm'>
+                            Don&apos;t have an account?{' '}
+                            <SecondaryLink to='/auth/register'>Sign up</SecondaryLink>
+                        </span>
+                    </div>
                 </LoginFormContainer>
             )}
         </Formik>

--- a/resources/scripts/components/auth/RegisterContainer.tsx
+++ b/resources/scripts/components/auth/RegisterContainer.tsx
@@ -1,0 +1,171 @@
+import type { FormikHelpers } from 'formik';
+import { Formik } from 'formik';
+import { object, ref, string } from 'yup';
+import register from '@/api/auth/register';
+import LoginFormContainer, { TitleSection } from '@/components/auth/LoginFormContainer';
+import Button from '@/components/elements/Button';
+import Captcha, { getCaptchaResponse } from '@/components/elements/Captcha';
+import Field from '@/components/elements/Field';
+
+import CaptchaManager from '@/lib/captcha';
+
+import useFlash from '@/plugins/useFlash';
+
+import SecondaryLink from '../ui/secondary-link';
+
+interface Values {
+    username: string;
+    email: string;
+    name_first: string;
+    name_last: string;
+    password: string;
+    password_confirmation: string;
+}
+
+function RegisterContainer() {
+    const { clearFlashes, clearAndAddHttpError } = useFlash();
+
+    const onSubmit = (values: Values, { setSubmitting }: FormikHelpers<Values>) => {
+        let registerData: Values = values;
+        if (CaptchaManager.isEnabled()) {
+            const captchaResponse = getCaptchaResponse();
+            const fieldName = CaptchaManager.getProviderInstance().getResponseFieldName();
+
+            if (fieldName) {
+                if (captchaResponse) {
+                    registerData = { ...values, [fieldName]: captchaResponse };
+                } else {
+                    clearAndAddHttpError({
+                        error: new Error('Please complete the captcha verification.'),
+                    });
+                    setSubmitting(false);
+                    return;
+                }
+            }
+        }
+
+        register(registerData)
+            .then((response) => {
+                if (response.complete) {
+                    clearFlashes();
+                    window.location.href = response.intended || '/';
+                }
+            })
+            .catch((error) => {
+                setSubmitting(false);
+                clearAndAddHttpError({ error });
+            });
+    };
+
+    return (
+        <Formik
+            onSubmit={onSubmit}
+            initialValues={{
+                username: '',
+                email: '',
+                name_first: '',
+                name_last: '',
+                password: '',
+                password_confirmation: '',
+            }}
+            validationSchema={object().shape({
+                username: string()
+                    .matches(
+                        /^[a-z0-9]([\w.-]+)[a-z0-9]$/,
+                        'Username must start and end with alphanumeric characters and contain only letters, numbers, dashes, underscores, and periods.',
+                    )
+                    .required('A username is required.'),
+                email: string().email('Enter a valid email address.').required('An email address is required.'),
+                name_first: string().required('Your first name is required.'),
+                name_last: string(),
+                password: string()
+                    .min(8, 'Your password must be at least 8 characters.')
+                    .required('A password is required.'),
+                password_confirmation: string()
+                    .required('Please confirm your password.')
+                    .oneOf([ref('password')], 'Passwords do not match.'),
+            })}
+        >
+            {({ isSubmitting }) => (
+                <LoginFormContainer className={`flex flex-col gap-6`}>
+                    <TitleSection title='Sign Up' subtitle='Create a new account' />
+                    <div className='grid grid-cols-2 gap-4'>
+                        <Field
+                            id='name_first'
+                            type={'text'}
+                            label={'First Name'}
+                            name={'name_first'}
+                            disabled={isSubmitting}
+                        />
+                        <Field
+                            id='name_last'
+                            type={'text'}
+                            label={'Last Name'}
+                            name={'name_last'}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div>
+                        <Field
+                            id='username'
+                            type={'text'}
+                            label={'Username'}
+                            name={'username'}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div>
+                        <Field
+                            id='email'
+                            type={'email'}
+                            label={'Email'}
+                            name={'email'}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div className='grid grid-cols-2 gap-4'>
+                        <Field
+                            id='password'
+                            type={'password'}
+                            label={'Password'}
+                            name={'password'}
+                            disabled={isSubmitting}
+                        />
+                        <Field
+                            id='password_confirmation'
+                            type={'password'}
+                            label={'Confirm Password'}
+                            name={'password_confirmation'}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+
+                    <Captcha
+                        className='mt-6'
+                        onError={(error) => {
+                            console.error('Captcha error:', error);
+                            clearAndAddHttpError({
+                                error: new Error('Captcha verification failed. Please try again.'),
+                            });
+                        }}
+                    />
+
+                    <div className='flex w-full justify-between items-center'>
+                        <Button
+                            className={`bg-mocha-100 rounded-lg p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 ease-in-out`}
+                            type={'submit'}
+                            size={'xlarge'}
+                            isLoading={isSubmitting}
+                            disabled={isSubmitting}
+                        >
+                            Sign Up
+                        </Button>
+                        <SecondaryLink to='/auth/login'>Already have an account?</SecondaryLink>
+                    </div>
+                </LoginFormContainer>
+            )}
+        </Formik>
+    );
+}
+
+export default RegisterContainer;

--- a/resources/scripts/routers/AuthenticationRouter.tsx
+++ b/resources/scripts/routers/AuthenticationRouter.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import ForgotPasswordContainer from '@/components/auth/ForgotPasswordContainer';
 import LoginCheckpointContainer from '@/components/auth/LoginCheckpointContainer';
 import LoginContainer from '@/components/auth/LoginContainer';
+import RegisterContainer from '@/components/auth/RegisterContainer';
 import ResetPasswordContainer from '@/components/auth/ResetPasswordContainer';
 import Logo from '@/components/elements/HydroLogo';
 import { NotFound } from '@/components/elements/ScreenBlock';
@@ -27,6 +28,7 @@ const AuthenticationRouter = () => {
                 <div className='w-full max-w-4xl z-2 flex items-center bg-bg-lowered align-middle px-[calc(var(--page-padding)*3)]'>
                     <Routes>
                         <Route path='login' element={<LoginContainer />} />
+                        <Route path='register' element={<RegisterContainer />} />
                         <Route path='login/checkpoint/*' element={<LoginCheckpointContainer />} />
                         <Route path='password' element={<ForgotPasswordContainer />} />
                         <Route path='password/reset/:token' element={<ResetPasswordContainer />} />

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -15,6 +15,7 @@ use Pterodactyl\Http\Controllers\Auth;
 // These routes are defined so that we can continue to reference them programmatically.
 // They all route to the same controller function which passes off to React.
 Route::get('/login', [Auth\LoginController::class, 'index'])->name('auth.login');
+Route::get('/register', [Auth\RegisterController::class, 'index'])->name('auth.register');
 Route::get('/password', [Auth\LoginController::class, 'index'])->name('auth.forgot-password');
 Route::get('/password/reset/{token}', [Auth\LoginController::class, 'index'])->name('auth.reset');
 
@@ -32,6 +33,12 @@ Route::middleware(['throttle:authentication'])->group(function () {
     Route::post('/password', [Auth\ForgotPasswordController::class, 'sendResetLinkEmail'])
         ->middleware('captcha')
         ->name('auth.post.forgot-password');
+
+    // Registration endpoint. A post to this endpoint will create a new user
+    // account with "User" rank (root_admin = false) and auto-login.
+    Route::post('/register', [Auth\RegisterController::class, 'register'])
+        ->middleware('captcha')
+        ->name('auth.register');
 });
 
 // Password reset routes. This endpoint is hit after going through


### PR DESCRIPTION
Adds a public registration flow so new users can create accounts without admin approval.

Backend:
- RegisterController with GET (SPA shell) and POST (create + auto-login)
- RegisterRequest with validation (username regex, email, name, password + confirmation)
- Route /auth/register with captcha and rate-limit (10 req/min)

Frontend:
- RegisterContainer.tsx — sign-up form with username, email, first/last name, password confirmation, and captcha
- register.ts — API helper for POST /auth/register
- Updated AuthenticationRouter and LoginContainer with sign-up link

New users are created with root_admin=false (regular 'User' rank).