### PR TITLE
feat: mobile UI overhaul (bottom nav, console, sidebar, auth)

### DIFF
--- a/resources/scripts/components/auth/ForgotPasswordContainer.tsx
+++ b/resources/scripts/components/auth/ForgotPasswordContainer.tsx
@@ -67,20 +67,6 @@ const ForgotPasswordContainer = () => {
                     <div className='text-sm mb-6'>We&apos;ll send you an email with a link to reset your password.</div>
                     <Field id='email' label={'Email'} name={'email'} type={'email'} />
 
-                    <div className='flex w-full justify-between items-center'>
-                        <Button
-                            className={`bg-mocha-100 text-black p-2 px-4 mt-4 rounded-full border-0 ring-0 outline-hidden capitalize`}
-                            type='submit'
-                            size='xlarge'
-                            isLoading={isSubmitting}
-                            disabled={isSubmitting}
-                        >
-                            Send Email
-                        </Button>
-
-                        <SecondaryLink to='/auth/login'>Return to Login?</SecondaryLink>
-                    </div>
-
                     <Captcha
                         className='mt-6'
                         onError={(error) => {
@@ -92,6 +78,22 @@ const ForgotPasswordContainer = () => {
                             });
                         }}
                     />
+
+                    <div className='flex w-full flex-col gap-3 mt-6 sm:flex-row sm:justify-between sm:items-center'>
+                        <Button
+                            className={`bg-mocha-100 text-black p-2 px-4 rounded-full border-0 ring-0 outline-hidden capitalize w-full sm:w-auto`}
+                            type='submit'
+                            size='xlarge'
+                            isLoading={isSubmitting}
+                            disabled={isSubmitting}
+                        >
+                            Send Email
+                        </Button>
+
+                        <SecondaryLink to='/auth/login' className='text-center sm:text-right'>
+                            Return to Login?
+                        </SecondaryLink>
+                    </div>
                 </LoginFormContainer>
             )}
         </Formik>

--- a/resources/scripts/components/auth/LoginCheckpointContainer.tsx
+++ b/resources/scripts/components/auth/LoginCheckpointContainer.tsx
@@ -47,9 +47,9 @@ function LoginCheckpointForm() {
                 />
             </div>
 
-            <div className='flex w-full justify-between items-center'>
+            <div className='flex w-full flex-col gap-3 sm:flex-row sm:justify-between sm:items-center'>
                 <Button
-                    className={`bg-mocha-100 rounded-full p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 hover:scale-102 ease-in-out`}
+                    className={`bg-mocha-100 rounded-full p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 hover:scale-102 ease-in-out w-full sm:w-auto`}
                     size={'xlarge'}
                     type={'submit'}
                     disabled={isSubmitting}
@@ -65,7 +65,7 @@ function LoginCheckpointForm() {
                         setIsMissingDevice((s) => !s);
                     }}
                     className={
-                        'block text-center py-2.5 px-4 text-xs font-medium tracking-wide uppercase text-white hover:text-white/80 transition-colors duration-200 border border-white/20 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30'
+                        'block text-center w-full sm:w-auto py-2.5 px-4 text-xs font-medium tracking-wide uppercase text-white hover:text-white/80 transition-colors duration-200 border border-white/20 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30'
                     }
                 >
                     {!isMissingDevice ? "I've Lost My Device" : 'I Have My Device'}

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -124,9 +124,9 @@ function LoginContainer() {
                         }}
                     />
 
-                    <div className='flex w-full justify-between items-center'>
+                    <div className='flex w-full flex-col gap-4 sm:flex-row sm:justify-between sm:items-center'>
                         <Button
-                            className={`bg-mocha-100 rounded-lg p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 ease-in-out`}
+                            className={`bg-mocha-100 rounded-lg p-2 px-4 text-black hover:cursor-pointer hover:bg-mocha-200 ease-in-out w-full sm:w-auto`}
                             type={'submit'}
                             size={'xlarge'}
                             isLoading={isSubmitting}
@@ -134,7 +134,9 @@ function LoginContainer() {
                         >
                             Sign in
                         </Button>
-                        <SecondaryLink to='/auth/password'>Forgot your password?</SecondaryLink>
+                        <SecondaryLink to='/auth/password' className='text-center sm:text-right'>
+                            Forgot your password?
+                        </SecondaryLink>
                     </div>
                 </LoginFormContainer>
             )}

--- a/resources/scripts/components/auth/LoginFormContainer.tsx
+++ b/resources/scripts/components/auth/LoginFormContainer.tsx
@@ -12,7 +12,7 @@ type Props = React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, 
 
 const TitleSection = ({ title, subtitle }: { title?: string; subtitle?: string }) => (
     <div className='space-y-2 font-medium mb-8'>
-        {title && <h2 className='text-3xl'>{title}</h2>}
+        {title && <h2 className='text-2xl sm:text-3xl'>{title}</h2>}
         {/*{subtitle && <span className='text-primary/40'>{subtitle}</span>}*/}
         {subtitle && <span className='text-secondary'>{subtitle}</span>}
     </div>

--- a/resources/scripts/components/auth/ResetPasswordContainer.tsx
+++ b/resources/scripts/components/auth/ResetPasswordContainer.tsx
@@ -154,11 +154,11 @@ function ResetPasswordContainer() {
                         <div aria-hidden className='my-8 bg-[#ffffff33] min-h-[1px]'></div>
 
                         <div
-                            className={`text-center w-full rounded-lg bg-[#ffffff33] border-0 ring-0 outline-hidden capitalize font-bold text-sm py-2 `}
+                            className={`text-center w-full rounded-lg bg-[#ffffff33] border-0 ring-0 outline-hidden capitalize font-bold text-sm py-3`}
                         >
                             <Link
                                 to={'/auth/login'}
-                                className={`text-xs text-white tracking-wide uppercase no-underline hover:text-neutral-700 border-color-[#ffffff33] pt-4`}
+                                className={`text-sm text-white tracking-wide uppercase no-underline hover:text-neutral-700 border-color-[#ffffff33]`}
                             >
                                 Return to Login
                             </Link>

--- a/resources/scripts/components/elements/Button.tsx
+++ b/resources/scripts/components/elements/Button.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import Spinner from '@/components/elements/Spinner';
 
@@ -10,7 +10,33 @@ interface Props {
     isSecondary?: boolean;
 }
 
-const ButtonStyle = styled.button<Omit<Props, 'isLoading'>>``;
+// Only min-height + font-size here. Padding is intentionally owned by each
+// call site's className — emitting padding here would fight it on equal
+// specificity (single-class selectors), making the winner injection-order
+// dependent.
+const SIZES = {
+    xsmall: css`
+        min-height: 1.5rem;
+        font-size: 0.75rem;
+    `,
+    small: css`
+        min-height: 2rem;
+        font-size: 0.875rem;
+    `,
+    large: css`
+        min-height: 2.75rem;
+        font-size: 0.95rem;
+    `,
+    xlarge: css`
+        min-height: 3rem;
+        font-size: 1rem;
+    `,
+} as const;
+
+const ButtonStyle = styled.button<Omit<Props, 'isLoading'>>`
+    position: relative;
+    ${({ size }) => size && SIZES[size]}
+`;
 
 type ComponentProps = Omit<JSX.IntrinsicElements['button'], 'ref' | keyof Props> & Props;
 

--- a/resources/scripts/components/elements/ContentBox.tsx
+++ b/resources/scripts/components/elements/ContentBox.tsx
@@ -11,7 +11,7 @@ type Props = Readonly<
 >;
 
 const ContentBox = ({ title, showFlashes, showLoadingOverlay, children, ...props }: Props) => (
-    <div className='p-8 bg-mocha-500 border-[1px] border-mocha-400 shadow-xs rounded-xl' {...props}>
+    <div className='p-4 sm:p-8 bg-mocha-500 border-[1px] border-mocha-400 shadow-xs rounded-xl' {...props}>
         {title && <h2 className={`font-extrabold mb-4  text-2xl`}>{title}</h2>}
         {showFlashes && <FlashMessageRender byKey={typeof showFlashes === 'string' ? showFlashes : undefined} />}
         <div>

--- a/resources/scripts/components/elements/Field.tsx
+++ b/resources/scripts/components/elements/Field.tsx
@@ -21,7 +21,7 @@ const Field = forwardRef<HTMLInputElement, Props>(
                         </label>
                     )}
                     <input
-                        className='px-4 py-2 rounded-lg outline-hidden bg-[#ffffff17] text-sm'
+                        className='px-4 py-2 rounded-lg outline-hidden bg-[#ffffff17] text-base sm:text-sm'
                         id={id}
                         {...field}
                         {...props}

--- a/resources/scripts/components/elements/Input.tsx
+++ b/resources/scripts/components/elements/Input.tsx
@@ -67,7 +67,10 @@ const inputStyle = css<Props>`
     border-radius: 0.5rem;
     outline: none;
     background-color: rgba(255, 255, 255, 0.09); /* Converted the hex color with alpha to rgba */
-    font-size: 0.875rem; /* 14px */
+    font-size: 1rem; /* 16px on mobile to prevent iOS Safari focus auto-zoom */
+    @media (min-width: 640px) {
+        font-size: 0.875rem;
+    }
 `;
 
 const Input = styled.input<Props>`

--- a/resources/scripts/components/elements/MainWrapper.tsx
+++ b/resources/scripts/components/elements/MainWrapper.tsx
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 const MainWrapper = styled.div`
     width: 100%;
     height: 100%;
+
+    /* On mobile, reserve space for the fixed BottomNav (h-14 = 3.5rem + safe-area)
+       so every page's internal scroll area ends above it instead of being
+       overlapped. Desktop (>=lg) is unaffected — the nav is hidden there. */
+    @media (max-width: 1023px) {
+        padding-bottom: calc(3.5rem + env(safe-area-inset-bottom));
+    }
 `;
 
 export default MainWrapper;

--- a/resources/scripts/components/elements/Modal.tsx
+++ b/resources/scripts/components/elements/Modal.tsx
@@ -121,7 +121,7 @@ const Modal: React.FC<ModalProps> = ({
                                 }}
                                 className={'fixed inset-0 backdrop-blur-xs z-9997'}
                             />
-                            <div className={'fixed inset-0 overflow-y-auto z-9998'}>
+                            <div className={'fixed inset-0 overflow-y-auto z-9998 pb-[env(safe-area-inset-bottom)]'}>
                                 <div
                                     ref={container}
                                     className={styles.dialogContainer}

--- a/resources/scripts/components/elements/PageContentBlock.tsx
+++ b/resources/scripts/components/elements/PageContentBlock.tsx
@@ -25,7 +25,7 @@ const PageContentBlock: React.FC<PageContentBlockProps> = ({
 
     return (
         <div
-            className={`${className || ''} max-w-[120rem] overflow-y-auto w-full mx-auto flex flex-col flex-1 h-full relative rounded-2xl ${background ? 'bg-bg-raised border border-mocha-400 p-7' : ''}`}
+            className={`${className || ''} max-w-[120rem] overflow-y-auto overscroll-y-contain w-full mx-auto flex flex-col flex-1 h-full relative rounded-2xl ${background ? 'bg-bg-raised border border-mocha-400 p-7' : ''}`}
         >
             {showFlashKey && <FlashMessageRender byKey={showFlashKey} />}
             {children}

--- a/resources/scripts/components/elements/Pagination.tsx
+++ b/resources/scripts/components/elements/Pagination.tsx
@@ -39,9 +39,9 @@ function Pagination<T>({ data: { items, pagination }, onPageSelect, children }: 
         <>
             {children({ items, isFirstPage, isLastPage })}
             {pages.length > 1 && (
-                <div className={`flex justify-center mt-4`}>
+                <div className={`flex justify-start mt-4 max-w-full overflow-x-auto`}>
                     <div
-                        className={`flex justify-center gap-3 p-[4px] w-fit bg-linear-to-b from-[#ffffff10] to-[#ffffff09] border border-[#00000017] rounded-md`}
+                        className={`flex justify-center gap-1.5 sm:gap-3 p-[4px] w-fit bg-linear-to-b from-[#ffffff10] to-[#ffffff09] border border-[#00000017] rounded-md shrink-0`}
                     >
                         <Block
                             isSecondary

--- a/resources/scripts/components/elements/dialog/Dialog.tsx
+++ b/resources/scripts/components/elements/dialog/Dialog.tsx
@@ -79,7 +79,7 @@ const Dialog = ({
                             }}
                             className={'fixed inset-0 backdrop-blur-xs z-9997'}
                         />
-                        <div className={'fixed inset-0 overflow-y-auto z-9998'}>
+                        <div className={'fixed inset-0 overflow-y-auto z-9998 pb-[env(safe-area-inset-bottom)]'}>
                             <div
                                 ref={container}
                                 className={styles.dialogContainer}

--- a/resources/scripts/components/layout/BottomNav.tsx
+++ b/resources/scripts/components/layout/BottomNav.tsx
@@ -1,0 +1,85 @@
+import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
+import { Fragment, memo } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+
+import Can from '@/components/elements/Can';
+import { cn } from '@/lib/utils';
+
+export interface BottomNavItem {
+    to: string;
+    icon: IconSvgElement;
+    text: string;
+    minimizedText?: string;
+    end?: boolean;
+    permission?: string | string[];
+}
+
+interface BottomNavProps {
+    items: BottomNavItem[];
+}
+
+// Mobile bottom navigation. Renders EVERY item in a horizontally-sliding
+// (scrollable) row — no truncation, no "More" button. On a dashboard with few
+// items they all fit; on a server page with many you slide left/right.
+// Hides its scrollbar for a clean native "sliding tab" feel.
+const BottomNav = memo(({ items }: BottomNavProps) => {
+    const location = useLocation();
+
+    if (items.length === 0) return null;
+
+    const isActive = (to: string, end?: boolean) =>
+        end ? location.pathname === to : location.pathname === to || location.pathname.startsWith(`${to}/`);
+
+    return (
+        <nav
+            aria-label='Primary navigation'
+            className='lg:hidden fixed inset-x-0 bottom-0 z-[9996] border-t border-mocha-400 bg-bg-lowered pb-[env(safe-area-inset-bottom)]'
+        >
+            <ul className='flex h-14 items-stretch gap-1 overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+                {items.map((item) => {
+                    const active = isActive(item.to, item.end);
+                    const label = item.minimizedText ?? item.text;
+                    const itemEl = (
+                        <li key={item.to} className='flex min-w-[72px] flex-1 items-stretch'>
+                            <NavLink
+                                to={item.to}
+                                end={item.end}
+                                aria-current={active ? 'page' : undefined}
+                                className='group flex w-full flex-col items-center justify-center gap-1 py-2 touch-manipulation'
+                            >
+                                <HugeiconsIcon
+                                    className={cn(
+                                        'size-5 transition-colors',
+                                        active ? 'text-brand' : 'text-white/55 group-hover:text-white',
+                                    )}
+                                    strokeWidth={2}
+                                    icon={item.icon}
+                                />
+                                <span
+                                    className={cn(
+                                        'max-w-full truncate text-[10px] leading-none transition-colors',
+                                        active ? 'font-semibold text-brand' : 'text-white/55 group-hover:text-white',
+                                    )}
+                                >
+                                    {label}
+                                </span>
+                            </NavLink>
+                        </li>
+                    );
+
+                    return item.permission ? (
+                        <Can key={item.to} action={item.permission} matchAny>
+                            {itemEl}
+                        </Can>
+                    ) : (
+                        <Fragment key={item.to}>{itemEl}</Fragment>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+});
+
+BottomNav.displayName = 'BottomNav';
+
+export default BottomNav;

--- a/resources/scripts/components/layout/sidebar/MobileSidebar.tsx
+++ b/resources/scripts/components/layout/sidebar/MobileSidebar.tsx
@@ -65,7 +65,7 @@ const MobileSidebarPanel = memo<{ navItems: NavItemData[] }>(({ navItems }) => {
                 )}
                 data-sidebar-minimized='false'
             >
-                <div className='sidebar-logo-container h-[64px] items-center mx-8 flex flex-none'>
+                <div className='sidebar-logo-container h-[64px] items-center mx-5 flex flex-none'>
                     <NavLink
                         to={'/'}
                         className='flex items-center shrink-0 h-8 w-fit hydrodactyl-logo'

--- a/resources/scripts/components/layout/sidebar/Sidebar.tsx
+++ b/resources/scripts/components/layout/sidebar/Sidebar.tsx
@@ -105,11 +105,11 @@ export default memo(function Sidebar({ navItems, className, onNavClick }: Sideba
     return (
         <div
             className={cn(
-                'sidebar-container flex-col shrink-0 rounded-lg px-8 select-none overflow-y-auto relative',
+                'sidebar-container flex-col shrink-0 rounded-lg px-5 select-none overflow-y-auto relative',
                 className,
             )}
         >
-            <div className='sidebar-indicator absolute bg-mocha-400 border border-mocha-300 left-[2rem] rounded-xl pointer-events-none' />
+            <div className='sidebar-indicator absolute bg-mocha-400 border border-mocha-300 left-[1.25rem] rounded-xl pointer-events-none' />
             <ul className='flex flex-col text-sm'>
                 {navItems.map((item, index) => {
                     const isActive = currentActiveTab === item.tabName;

--- a/resources/scripts/components/layout/sidebar/sidebar-modern.css
+++ b/resources/scripts/components/layout/sidebar/sidebar-modern.css
@@ -6,7 +6,7 @@
     --sidebar-transition-sidebar: 0.4s cubic-bezier(0.23, 1.2, 0.32, 1);
     --sidebar-text-scale-small: 0.86; /* 12px (text-xs) / 14px (text-sm) */
     --sidebar-margin-base: 0.75rem;
-    --sidebar-padding: 2rem; /* 32px, mx-8 */
+    --sidebar-padding: 1.25rem; /* 20px, px-5 */
     --sidebar-full-width: 300px;
     --sidebar-minimized-width: 128px;
 }
@@ -41,9 +41,9 @@ body[data-sidebar-minimized="true"] .sidebar-logo-container {
     width: calc(var(--sidebar-width));
 }
 body[data-sidebar-minimized="false"] .sidebar-logo-container {
-    /* -64px because the padding is 32px (mx-8)
+    /* -40px because the padding is 20px (px-5)
        this puts the toggle button in line with the items */
-    width: calc(var(--sidebar-width) - 64px);
+    width: calc(var(--sidebar-width) - 2.5rem);
 }
 
 .sidebar-indicator {
@@ -67,7 +67,7 @@ body[data-sidebar-minimized="true"] .nav-item {
 }
 body[data-sidebar-minimized="false"] .nav-item {
     /* 32px height, 8px used for padding */
-    @apply h-10 flex-row items-center gap-2 pl-3;
+    @apply h-10 w-full flex-row items-center gap-2 pl-3;
 }
 
 body[data-sidebar-minimized="true"] .nav-item .nav-icon {
@@ -102,4 +102,27 @@ body[data-sidebar-minimized="false"] .nav-item .nav-text {
 /* active tab highlighting - applies to the active tab when only when nothing's hovered */
 .sidebar-container:not(:has(li:hover)) li[data-active="true"] a {
     @apply !text-cream-400 !fill-cream-400 opacity-100;
+}
+
+/* ---- Mobile drawer ----
+   On mobile the <body> stays in the "minimized" state (the desktop rail is hidden),
+   so the drawer's items would otherwise inherit the minimized "icon-chip" styles and
+   render as tiny icon-only chips with a huge empty right gap. These rules force
+   full-width, left-aligned rows, scoped to the drawer panel (the only .sidebar-container
+   carrying data-sidebar-minimized="false") so the desktop rail is untouched.
+   No `!important` is needed: this selector (.sidebar-container[...] .nav-item,
+   specificity (0,3,0)) already outranks the body[data-sidebar-minimized="true"] .nav-item
+   rules (0,2,1). */
+.sidebar-container[data-sidebar-minimized="false"] .nav-item {
+    width: 100%;
+    height: 2.75rem;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.75rem;
+    padding-left: 0.75rem;
+    text-align: left;
+}
+.sidebar-container[data-sidebar-minimized="false"] .nav-item .nav-text {
+    transform: none;
 }

--- a/resources/scripts/components/server/WebsocketHandler.tsx
+++ b/resources/scripts/components/server/WebsocketHandler.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import getWebsocketToken from '@/api/server/getWebsocketToken';
 import Spinner from '@/components/elements/Spinner';
 import FadeTransition from '@/components/elements/transitions/FadeTransition';
@@ -14,6 +14,13 @@ function WebsocketHandler() {
     const uuid = ServerContext.useStoreState((state) => state.server.data?.uuid);
     const setServerStatus = ServerContext.useStoreActions((actions) => actions.status.setServerStatus);
     const { setInstance, setConnectionState } = ServerContext.useStoreActions((actions) => actions.socket);
+
+    // Mirror the live connection state into refs so the one-shot visibility
+    // listener below can read the latest values without re-registering.
+    const connectedRef = useRef(connected);
+    const instanceRef = useRef(instance);
+    connectedRef.current = connected;
+    instanceRef.current = instance;
 
     const updateToken = (uuid: string, socket: Websocket) => {
         if (updatingToken) {
@@ -104,6 +111,39 @@ function WebsocketHandler() {
         connect(uuid);
         // biome-ignore lint/correctness/useExhaustiveDependencies: connect is intentionally recreated
     }, [uuid, instance, connect]);
+
+    useEffect(() => {
+        // Mobile browsers suspend/kill the websocket when the tab is backgrounded
+        // (e.g. the user returns to the home screen). Sockette's auto-reconnect
+        // doesn't reliably resume in that case — its timers were frozen and a
+        // clean close event may never fire — so the console is left empty until a
+        // manual page reload. When the tab becomes visible again (or the network
+        // comes back online), give pending close events a moment to settle, then
+        // force a reconnect if we're no longer connected. On reconnect the socket
+        // re-authenticates and the Console component re-requests SEND_LOGS, so the
+        // buffer refills automatically.
+        let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+        const attemptReconnect = () => {
+            if (reconnectTimer) clearTimeout(reconnectTimer);
+            reconnectTimer = window.setTimeout(() => {
+                const socket = instanceRef.current;
+                if (socket && !connectedRef.current) {
+                    socket.reconnect();
+                }
+            }, 300);
+        };
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') attemptReconnect();
+        };
+
+        document.addEventListener('visibilitychange', onVisibility);
+        window.addEventListener('online', attemptReconnect);
+        return () => {
+            document.removeEventListener('visibilitychange', onVisibility);
+            window.removeEventListener('online', attemptReconnect);
+            if (reconnectTimer) clearTimeout(reconnectTimer);
+        };
+    }, []);
 
     return error ? (
         <FadeTransition duration='duration-150' show>

--- a/resources/scripts/components/server/console/Console.tsx
+++ b/resources/scripts/components/server/console/Console.tsx
@@ -4,6 +4,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { type ITerminalOptions, Terminal } from '@xterm/xterm';
 import { useSidebar } from '@/contexts/SidebarContext';
 import '@xterm/xterm/css/xterm.css';
+import './console.css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -14,6 +15,7 @@ import KeyboardShortcut from '@/components/ui/keyboard-shortcut';
 import { cn } from '@/lib/utils';
 import { usePermissions } from '@/plugins/usePermissions';
 import { usePersistedState } from '@/plugins/usePersistedState';
+import { ScrollDownHelperAddon } from '@/plugins/XtermScrollDownHelperAddon';
 import { ServerContext } from '@/state/server';
 
 const theme = {
@@ -57,12 +59,16 @@ const Console = () => {
     const fitAddon = useMemo(() => new FitAddon(), []);
     const searchAddon = useMemo(() => new SearchAddon(), []);
     const webLinksAddon = useMemo(() => new WebLinksAddon(), []);
+    const scrollDownHelperAddon = useMemo(() => new ScrollDownHelperAddon(), []);
     const { connected, instance } = ServerContext.useStoreState((state) => state.socket);
     const [canSendCommands] = usePermissions(['control.console']);
     const serverId = ServerContext.useStoreState((state) => state.server.data?.id);
     const isTransferring = ServerContext.useStoreState((state) => state.server.data?.isTransferring);
     const [history, setHistory] = usePersistedState<string[]>(`${serverId}:command_history`, []);
     const [historyIndex, setHistoryIndex] = useState(-1);
+    // Bumped when the tab becomes visible again so the listeners effect re-runs
+    // (clear + SEND_LOGS) and refills a terminal left blank after backgrounding.
+    const [visibilityTick, setVisibilityTick] = useState(0);
     const { isMinimized: _isMinimized } = useSidebar();
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -193,9 +199,23 @@ const Console = () => {
                 terminal.loadAddon(fitAddon);
                 terminal.loadAddon(searchAddon);
                 terminal.loadAddon(webLinksAddon);
+                terminal.loadAddon(scrollDownHelperAddon);
 
                 terminal.open(ref.current);
                 fitAddon.fit();
+
+                // Lock the terminal canvas. The hidden `.xterm-helper-textarea` is
+                // xterm's only keyboard entry point — disabling it (and dropping it
+                // from the tab order) means the canvas can never gain focus and no
+                // keystrokes reach xterm's input pipeline, so nothing (scroll-on-key,
+                // the copy handler below, IME, etc.) ever fires. This is on top of
+                // `disableStdin`, which only suppresses emitted data. Output rendering,
+                // mouse text-selection, and native viewport scrolling are unaffected;
+                // command input still flows through the dedicated box below.
+                if (terminal.textarea) {
+                    terminal.textarea.tabIndex = -1;
+                    terminal.textarea.disabled = true;
+                }
 
                 // Add support for capturing keys
                 terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
@@ -233,7 +253,7 @@ const Console = () => {
                 resizeObserverRef.current = null;
             }
         };
-    }, [terminal, connected, fitAddon, searchAddon, webLinksAddon, debouncedFit]);
+    }, [terminal, connected, fitAddon, searchAddon, webLinksAddon, scrollDownHelperAddon, debouncedFit]);
 
     // useEventListener(
     //     'resize',
@@ -248,6 +268,10 @@ const Console = () => {
         debouncedFit();
     }, [debouncedFit]);
 
+    // visibilityTick is an intentional trigger dep: it isn't read in the body, it
+    // only forces this effect to re-run (clear + SEND_LOGS) when the tab becomes
+    // visible again, so a terminal left blank after backgrounding refills.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: visibilityTick is a deliberate re-run trigger
     useEffect(() => {
         const listeners: Record<string, (s: string) => void> = {
             [SocketEvent.STATUS]: handlePowerChangeEvent,
@@ -297,7 +321,23 @@ const Console = () => {
         handleDaemonErrorOutput,
         handlePowerChangeEvent,
         handleTransferStatus,
+        visibilityTick,
     ]);
+
+    // On phones, backgrounding the app (home screen) freezes this component, so
+    // when the user returns the socket is often still/again connected (stats keep
+    // flowing) but the terminal can be left blank — its effects never re-ran while
+    // frozen. Bumping visibilityTick on return re-runs the listeners effect above
+    // (clear + SEND_LOGS), repopulating the console instead of leaving it empty.
+    useEffect(() => {
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') {
+                setVisibilityTick((tick) => tick + 1);
+            }
+        };
+        document.addEventListener('visibilitychange', onVisibility);
+        return () => document.removeEventListener('visibilitychange', onVisibility);
+    }, []);
 
     return (
         <div className='flex w-full h-full'>
@@ -305,31 +345,36 @@ const Console = () => {
                 <SpinnerOverlay visible={!connected} size={'large'} />
                 <div
                     className={cn(
-                        'bg-bg-raised border-mocha-400 p-4 flex flex-1 flex-col overflow-hidden rounded-2xl border text-sm',
-                        {
-                            'rounded-b': !canSendCommands,
-                        },
+                        // `console-terminal-host` decouples the terminal's scroll from the
+                        // page (see console.css): on touch devices the canvas lets touches
+                        // fall through to .xterm-viewport so the COMPOSITOR scrolls the
+                        // buffer natively (GPU-smooth, not xterm's main-thread handler that
+                        // stutters on phones), and overscroll-behavior:contain keeps it from
+                        // chaining to the page. Desktop (mouse) is untouched. This is the
+                        // "separate the xterm console from the console page" behaviour.
+                        'console-terminal-host bg-bg-raised border-mocha-400 p-4 flex min-h-[260px] lg:flex-1 lg:min-h-0 flex-col overflow-hidden rounded-t-2xl border text-sm',
+                        canSendCommands ? 'rounded-b-none border-b-0' : 'rounded-b-2xl',
                     )}
                 >
-                    <div className='size-full' ref={ref} />
-
-                    {canSendCommands && (
-                        <div className='w-full rounded-2xl border border-mocha-300 bg-mocha-400 p-2 text-zinc-100 flex px-(--padding-x) relative [--padding-x:--spacing(4)] text-sm'>
-                            <input
-                                ref={inputRef}
-                                className='w-full'
-                                type={'text'}
-                                placeholder={'Enter a command'}
-                                aria-label={'Console command input.'}
-                                disabled={!instance || !connected}
-                                onKeyDown={handleCommandKeyDown}
-                                autoCorrect={'off'}
-                                autoCapitalize={'none'}
-                            />
-                            <KeyboardShortcut keys={['/']} variant='faded' className='pl-(--padding-x)' />
-                        </div>
-                    )}
+                    <div className='h-full' ref={ref} />
                 </div>
+
+                {canSendCommands && (
+                    <div className='w-full shrink-0 rounded-b-2xl rounded-t-none border border-t-0 border-mocha-300 bg-mocha-400 p-2 text-zinc-100 flex px-(--padding-x) relative [--padding-x:--spacing(4)] text-sm'>
+                        <input
+                            ref={inputRef}
+                            className='w-full'
+                            type={'text'}
+                            placeholder={'Enter a command'}
+                            aria-label={'Console command input.'}
+                            disabled={!instance || !connected}
+                            onKeyDown={handleCommandKeyDown}
+                            autoCorrect={'off'}
+                            autoCapitalize={'none'}
+                        />
+                        <KeyboardShortcut keys={['/']} variant='faded' className='pl-(--padding-x)' />
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/resources/scripts/components/server/console/ServerConsoleContainer.tsx
+++ b/resources/scripts/components/server/console/ServerConsoleContainer.tsx
@@ -21,9 +21,9 @@ const ServerConsoleContainer = () => {
     const isNodeUnderMaintenance = ServerContext.useStoreState((state) => state.server.data?.isNodeUnderMaintenance);
 
     return (
-        <PageContentBlock title={'Console'} background={false} className='overflow-y-visible'>
-            <div className='w-full h-full flex flex-col lg:flex-row gap-4'>
-                <div className='flex flex-col flex-1 gap-4'>
+        <PageContentBlock title={'Console'} background={false}>
+            <div className='w-full flex flex-col gap-4 lg:h-full lg:flex-row'>
+                <div className='flex flex-col gap-4 lg:flex-1 lg:min-h-0'>
                     <ServerHeader powerButtons={true} />
                     <PowerButtons className='flex lg:hidden gap-2 items-center justify-center' />
                     {(isNodeUnderMaintenance || isInstalling || isTransferring) && (
@@ -35,9 +35,11 @@ const ServerConsoleContainer = () => {
                                   : 'This server is currently being transferred to another node and all actions are unavailable.'}
                         </Alert>
                     )}
-                    <Console />
+                    <div className='lg:h-full lg:flex-1 lg:min-h-0'>
+                        <Console />
+                    </div>
                 </div>
-                <div className='relative w-full lg:w-(--sidebar-full-width) overflow-y-auto overflow-x-visible lg:flex-none lg:-mb-(--main-wrapper-spacing) lg:pb-(--main-wrapper-spacing)'>
+                <div className='relative w-full overflow-x-visible lg:w-(--sidebar-full-width) lg:overflow-y-auto lg:flex-none lg:-mb-(--main-wrapper-spacing) lg:pb-(--main-wrapper-spacing)'>
                     <div className='flex flex-col gap-4'>
                         <Spinner.Suspense>
                             <StatGraphs />

--- a/resources/scripts/components/server/console/console.css
+++ b/resources/scripts/components/server/console/console.css
@@ -1,0 +1,42 @@
+/*
+ * Separate the xterm terminal's scroll from the page scroll — SMOOTHLY.
+ *
+ * The problem this solves:
+ *   xterm renders its canvas (.xterm-screen) ON TOP of the scrollable
+ *   .xterm-viewport. So a touch on the terminal lands on the canvas, and the
+ *   only way the buffer scrolls is via xterm's OWN touchmove handler, which
+ *   runs on the MAIN THREAD (Viewport.handleTouchMove does scrollTop += delta).
+ *   Main-thread-driven scroll stutters/hangs on real phones even when CPU
+ *   profiling shows zero long tasks, because the compositor can't drive it.
+ *
+ *   `touch-action: none` (a previous attempt) makes this WORSE: it tells the
+ *   browser to do no native touch handling, forcing 100% of terminal drags
+ *   through that main-thread handler.
+ *
+ * The fix:
+ *   On touch devices only, set `pointer-events: none` on the canvas/screen so
+ *   the touch falls THROUGH to the .xterm-viewport behind it. The browser's
+ *   COMPOSITOR then scrolls the viewport natively (GPU-smooth — this is what
+ *   xterm listens to via the viewport's scroll event to render the buffer).
+ *   `overscroll-behavior-y: contain` on the viewport keeps that scroll from
+ *   chaining to the page, so the terminal and page stay decoupled — the
+ *   "separate the xterm console from the console page" behaviour.
+ *
+ *   Scoped to `@media (pointer: coarse)` (touch devices) so DESKTOP is
+ *   completely unaffected: there the canvas keeps pointer events and xterm's
+ *   wheel handler + text selection work as normal.
+ *
+ *   Desktop mouse users are unaffected; mobile terminal text-selection via
+ *   long-press is the only trade-off (rarely needed on a game-server console,
+ *   which is disableStdin + live output).
+ */
+@media (pointer: coarse) {
+    .console-terminal-host .xterm-screen,
+    .console-terminal-host .xterm canvas {
+        pointer-events: none;
+    }
+    .console-terminal-host .xterm-viewport {
+        overscroll-behavior-y: contain;
+        -webkit-overflow-scrolling: touch;
+    }
+}

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -155,7 +155,7 @@ const FileEditContainer = () => {
                 }}
             />
 
-            <div className='h-full relative bg-[#ffffff11] border-[1px] border-[#ffffff07] border-t-0 [&>div>div]:h-full [&>div>div]:outline-hidden! w-full flex-grow'>
+            <div className='h-full relative bg-[#ffffff11] border-[1px] border-[#ffffff07] border-t-0 [&>div>div]:h-full [&>div>div]:outline-hidden! w-full flex-grow order-20 lg:order-none'>
                 <Editor
                     filename={filename}
                     initialContent={content}
@@ -177,7 +177,7 @@ const FileEditContainer = () => {
                 />
             </div>
 
-            <div className='flex flex-row items-center gap-4 absolute top-2.5 right-2'>
+            <div className='flex flex-row flex-wrap items-center justify-between gap-2 px-1 py-2 order-10 lg:order-none lg:flex-nowrap lg:justify-start lg:px-0 lg:py-0 lg:absolute lg:top-2.5 lg:right-2 lg:gap-4'>
                 <DropdownMenu>
                     <DropdownMenuTrigger className='flex items-center gap-2 font-bold text-sm px-3 py-1 rounded-md h-fit bg-[#ffffff11]'>
                         <svg
@@ -210,7 +210,7 @@ const FileEditContainer = () => {
                                 strokeLinejoin='round'
                             />
                         </svg>
-                        <span className='sm:block hidden'>{language?.name ?? 'Language'}</span>
+                        <span className='block'>{language?.name ?? 'Language'}</span>
                         <svg
                             xmlns='http://www.w3.org/2000/svg'
                             width='13'
@@ -249,7 +249,7 @@ const FileEditContainer = () => {
                         <div className='flex gap-1 items-center justify-center'>
                             <Button
                                 size='lg'
-                                className='rounded-l-full rounded-r-none pl-8 pr-6'
+                                className='rounded-l-full rounded-r-none px-4 sm:pl-8 sm:pr-6'
                                 onClick={() => save()}
                             >
                                 Save{' '}
@@ -272,7 +272,7 @@ const FileEditContainer = () => {
                                                 fillRule='evenodd'
                                                 clipRule='evenodd'
                                                 d='M3.39257 5.3429C3.48398 5.25161 3.60788 5.20033 3.73707 5.20033C3.86626 5.20033 3.99016 5.25161 4.08157 5.3429L6.49957 7.7609L8.91757 5.3429C8.9622 5.29501 9.01602 5.25659 9.07582 5.22995C9.13562 5.2033 9.20017 5.18897 9.26563 5.18782C9.33109 5.18667 9.39611 5.19871 9.45681 5.22322C9.51751 5.24774 9.57265 5.28424 9.61895 5.33053C9.66524 5.37682 9.70173 5.43196 9.72625 5.49267C9.75077 5.55337 9.76281 5.61839 9.76166 5.68384C9.7605 5.7493 9.74617 5.81385 9.71953 5.87365C9.69288 5.93345 9.65447 5.98727 9.60657 6.0319L6.84407 8.7944C6.75266 8.8857 6.62876 8.93698 6.49957 8.93698C6.37038 8.93698 6.24648 8.8857 6.15507 8.7944L3.39257 6.0319C3.30128 5.9405 3.25 5.81659 3.25 5.6874C3.25 5.55822 3.30128 5.43431 3.39257 5.3429Z'
-                                                fill='white'
+                                                fill='currentColor'
                                             />
                                         </svg>
                                     </Button>

--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -60,7 +60,7 @@ const MassActionsBar = () => {
     };
 
     return (
-        <div className={`pointer-events-none fixed bottom-0 z-20 left-0 right-0 flex justify-center`}>
+        <div className={`pointer-events-none fixed bottom-0 z-[9997] left-0 right-0 flex justify-center`}>
             <SpinnerOverlay visible={loading} size={'large'} fixed>
                 {loadingMessage}
             </SpinnerOverlay>
@@ -93,7 +93,9 @@ const MassActionsBar = () => {
             )}
             <FadeTransition duration='duration-75' show={selectedFiles.length > 0} appear unmount>
                 <div
-                    className={'pointer-events-none fixed bottom-0 left-0 right-0 mb-6 flex justify-center w-full z-50'}
+                    className={
+                        'pointer-events-none fixed bottom-0 left-0 right-0 mb-[calc(4rem+env(safe-area-inset-bottom))] lg:mb-6 flex justify-center w-full z-50'
+                    }
                 >
                     <div className={`flex items-center space-x-4 pointer-events-auto rounded-sm p-4 bg-black/50`}>
                         <Button onClick={() => setShowMove(true)} disabled={loading}>

--- a/resources/scripts/components/server/network/NetworkContainer.tsx
+++ b/resources/scripts/components/server/network/NetworkContainer.tsx
@@ -63,7 +63,7 @@ const NetworkContainer = () => {
             <FlashMessageRender byKey={'server:network'} />
 
             <div className=''>
-                <div className='rounded-xl shadow-sm px-14 py-14'>
+                <div className='rounded-xl shadow-sm px-4 py-8 sm:px-14 sm:py-14'>
                     <div className='flex items-center justify-between mb-2'>
                         {data && (
                             <Can action={'allocation.create'}>

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -266,7 +266,7 @@ const StartupContainer = () => {
                                         </span>
                                         <CopyOnClick text={liveProcessedCommand}>
                                             <div className='cursor-pointer group'>
-                                                <div className='w-full h-32 sm:h-36 md:h-40 px-3 py-3 sm:px-4 sm:py-4 font-mono bg-linear-to-b from-[#ffffff06] to-[#ffffff03] border-2 border-green-500/20 rounded-xl text-sm sm:text-base overflow-auto group-hover:border-green-500/40 transition-all'>
+                                                <div className='w-full min-h-[8rem] sm:min-h-[9rem] md:min-h-[10rem] px-3 py-3 sm:px-4 sm:py-4 font-mono bg-linear-to-b from-[#ffffff06] to-[#ffffff03] border-2 border-green-500/20 rounded-xl text-sm sm:text-base overflow-auto group-hover:border-green-500/40 transition-all'>
                                                     <span
                                                         className='break-all text-green-200'
                                                         style={{

--- a/resources/scripts/plugins/XtermScrollDownHelperAddon.ts
+++ b/resources/scripts/plugins/XtermScrollDownHelperAddon.ts
@@ -1,0 +1,141 @@
+import type { ITerminalAddon, Terminal } from '@xterm/xterm';
+
+/**
+ * A "scroll to bottom" helper for the xterm console — a small down-arrow
+ * button pinned to the bottom-right of the terminal. It appears when the user
+ * has scrolled up in the buffer (newer output hidden below the fold) and
+ * disappears when they're back at the bottom. Clicking it jumps to the latest
+ * output. Ported from upstream Pterodactyl's plugin of the same name.
+ *
+ * IMPORTANT — why this uses the NATIVE viewport scroll event, not xterm's
+ * `terminal.onScroll` / `buffer.active.viewportY`:
+ *   With console.css routing touches to `.xterm-viewport` (so the compositor
+ *   scrolls the buffer natively), the buffer is scrolled by moving the
+ *   viewport element's `scrollTop`. In this xterm v5.5.0 + DOM-renderer build
+ *   that DOES update the rendered rows, but it does NOT update
+ *   `buffer.active.viewportY` or emit `terminal.onScroll` for user scrolls
+ *   (those only fire on xterm's own auto-scroll on new output). So
+ *   `viewportY === baseY` is unreliable here. Instead we listen to the
+ *   viewport element's native `scroll` event and compare `scrollTop` to the
+ *   max — which tracks real user/programmatic scroll position correctly.
+ *
+ * The button is appended to `terminal.element` (the `.xterm` host) as a direct
+ * child, NOT inside `.xterm-screen` — so the console.css `pointer-events: none`
+ * rule on `.xterm-screen` doesn't affect it; it stays tappable.
+ */
+export class ScrollDownHelperAddon implements ITerminalAddon {
+    private terminal!: Terminal;
+    private viewport: HTMLElement | null = null;
+    private element?: HTMLDivElement;
+    private waitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    activate(terminal: Terminal): void {
+        this.terminal = terminal;
+        // The addon is loaded before terminal.open(), so terminal.element (and
+        // the viewport) don't exist yet — wait for them.
+        this.waitForViewport();
+
+        // New output while the user is scrolled up → reveal the button so they
+        // know fresher output is below. (onLineFeed fires on every writeln.)
+        this.terminal.onLineFeed(() => {
+            if (!this.isAtBottom()) {
+                this.show();
+            }
+        });
+    }
+
+    dispose(): void {
+        if (this.waitTimer) clearTimeout(this.waitTimer);
+        if (this.viewport) this.viewport.removeEventListener('scroll', this.handleScroll);
+        if (this.element) {
+            this.element.remove();
+            this.element = undefined;
+        }
+    }
+
+    private waitForViewport = () => {
+        const el = this.terminal.element;
+        const vp = el ? (el.querySelector('.xterm-viewport') as HTMLElement | null) : null;
+        if (vp) {
+            this.viewport = vp;
+            vp.addEventListener('scroll', this.handleScroll, { passive: true });
+            this.handleScroll(); // set initial visibility
+            return;
+        }
+        this.waitTimer = setTimeout(this.waitForViewport, 50);
+    };
+
+    private handleScroll = (): void => {
+        if (this.isAtBottom()) {
+            this.hide();
+        } else {
+            this.show();
+        }
+    };
+
+    private isAtBottom(): boolean {
+        const vp = this.viewport;
+        if (!vp) return true;
+        return vp.scrollTop >= vp.scrollHeight - vp.clientHeight - 2;
+    }
+
+    private show(): void {
+        if (!this.terminal?.element) {
+            return;
+        }
+        if (this.element) {
+            this.element.style.opacity = '1';
+            this.element.style.pointerEvents = 'auto';
+            return;
+        }
+
+        this.terminal.element.style.position = 'relative';
+
+        this.element = document.createElement('div');
+        this.element.innerHTML =
+            '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" style="width:1em;height:1em;display:block;"><path fill="currentColor" d="M374.6 310.6l-160 160C208.4 476.9 200.2 480 192 480s-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L160 370.8V64c0-17.69 14.33-31.1 31.1-31.1S224 46.31 224 64v306.8l105.4-105.4c12.5-12.5 32.75-12.5 45.25 0S387.1 298.1 374.6 310.6z"/></svg>';
+        Object.assign(this.element.style, {
+            position: 'absolute',
+            right: '0.75rem',
+            bottom: '0.75rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '2rem',
+            height: '2rem',
+            fontSize: '1rem',
+            color: '#e5e5e5',
+            backgroundColor: 'rgba(38, 36, 40, 0.92)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: '0.5rem',
+            boxShadow: '0 2px 10px rgba(0,0,0,0.45)',
+            zIndex: '20',
+            cursor: 'pointer',
+            opacity: '1',
+            transition: 'opacity 120ms ease',
+            // never let the terminal's touch-scroll isolation swallow the tap
+            touchAction: 'manipulation',
+        } as Partial<CSSStyleDeclaration>);
+        this.element.setAttribute('role', 'button');
+        this.element.setAttribute('aria-label', 'Scroll console to bottom');
+        this.element.title = 'Scroll to bottom';
+
+        this.element.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (this.viewport) {
+                this.viewport.scrollTop = this.viewport.scrollHeight;
+            } else {
+                this.terminal.scrollToBottom();
+            }
+        });
+
+        this.terminal.element.appendChild(this.element);
+    }
+
+    private hide(): void {
+        if (this.element) {
+            this.element.style.opacity = '0';
+            this.element.style.pointerEvents = 'none';
+        }
+    }
+}

--- a/resources/scripts/routers/AuthenticationRouter.tsx
+++ b/resources/scripts/routers/AuthenticationRouter.tsx
@@ -23,8 +23,8 @@ const AuthenticationRouter = () => {
                 }}
                 className='pointer-events-none fixed inset-0 z-1 opacity-[0.4]'
             ></div>
-            <div className='flex size-full'>
-                <div className='w-full max-w-4xl z-2 flex items-center bg-bg-lowered align-middle px-[calc(var(--page-padding)*3)]'>
+            <div className='flex size-full flex-col lg:flex-row'>
+                <div className='w-full max-w-4xl z-2 flex items-start sm:items-center bg-bg-lowered min-h-dvh lg:min-h-0 px-6 py-8 sm:px-[calc(var(--page-padding)*3)] overflow-y-auto'>
                     <Routes>
                         <Route path='login' element={<LoginContainer />} />
                         <Route path='login/checkpoint/*' element={<LoginCheckpointContainer />} />
@@ -33,7 +33,7 @@ const AuthenticationRouter = () => {
                         <Route path='*' element={<NotFound />} />
                     </Routes>
                 </div>
-                <div className='w-full relative'>
+                <div className='hidden lg:block w-full relative'>
                     <div className='flex items-center gap-4 h-6 absolute right-(--page-padding) top-(--page-padding) text-lg'>
                         <Logo className='h-full w-full flex inset-0' />
                         <div className='border-l border-gray-200 h-full' />

--- a/resources/scripts/routers/UnifiedRouter.tsx
+++ b/resources/scripts/routers/UnifiedRouter.tsx
@@ -27,6 +27,7 @@ import Logo from '@/components/elements/HydroLogo';
 import MainWrapper from '@/components/elements/MainWrapper';
 import PermissionRoute from '@/components/elements/PermissionRoute';
 import { NotFound, ServerError } from '@/components/elements/ScreenBlock';
+import BottomNav from '@/components/layout/BottomNav';
 import AppHeader from '@/components/layout/header/AppHeader';
 import MobileSidebar from '@/components/layout/sidebar/MobileSidebar';
 import Sidebar from '@/components/layout/sidebar/Sidebar';
@@ -332,6 +333,7 @@ const UnifiedRouter = () => {
                         <div className='flex flex-col lg:flex-row h-full w-full overflow-hidden relative'>
                             <Sidebar navItems={navItems} className='hidden lg:flex' />
                             <MobileSidebar navItems={navItems} />
+                            <BottomNav items={navItems} />
 
                             {/* server-specific components - only render when we have server data */}
                             {isServerRoute && uuid && id && (


### PR DESCRIPTION
## Summary
Broad mobile/responsive pass plus console robustness.

## Changes
- **Mobile nav:** new `BottomNav` (horizontally-sliding tab row, no truncation); `MainWrapper` reserves its height on mobile so page content isn't overlapped.
- **Console (mobile):** decouple the xterm scroll from the page (`console.css` sets `pointer-events:none` on the canvas on touch devices → compositor-driven native scroll); add a scroll-to-bottom helper addon; lock the terminal stdin so the canvas can't be focused / receive keystrokes; restructure the console layout to fill height on desktop.
- **Auth:** stack buttons and links vertically on mobile (`sm:` row), reflow `AuthenticationRouter` for small screens.
- **Sidebar:** reduce horizontal padding 32px → 20px across desktop + mobile (active indicator + logo kept in sync).
- **Files:** reflow the file-editor toolbar on mobile.
- **Websocket:** reconnect on tab visibility / `online` events (with timer cleanup) so the console refills after backgrounding on mobile.
- **Button:** size-based min-height / font-size.
- **Forms & elements:** prevent iOS Safari input zoom (16px on mobile) and apply mobile-responsive spacing / safe-area / scroll.

## Verification
- `pnpm build` ✓
- `biome check` clean on all changed files