### PR TITLE
S3 Storage Region fix

### DIFF
--- a/app/Http/Controllers/Admin/S3Controller.php
+++ b/app/Http/Controllers/Admin/S3Controller.php
@@ -111,13 +111,14 @@ class S3Controller extends Controller
             'secret_key' => 'required|string',
             'bucket_name' => 'required|string',
             'endpoint' => 'nullable|string',
+            'region' => 'nullable|string|max:64',
             'use_path_style_endpoint' => 'nullable|boolean',
         ]);
 
         try {
             $config = [
                 'version' => 'latest',
-                'region' => 'us-east-1',
+                'region' => trim((string) $request->input('region', '')) ?: 'us-east-1',
                 'credentials' => [
                     'key' => $request->input('access_key'),
                     'secret' => $request->input('secret_key'),

--- a/app/Http/Requests/Admin/NewS3FormRequest.php
+++ b/app/Http/Requests/Admin/NewS3FormRequest.php
@@ -12,6 +12,7 @@ class NewS3FormRequest extends AdminFormRequest
             'access_key' => 'required|string|max:255',
             'secret_key' => 'required|string|max:255',
             'endpoint' => 'nullable|url|max:255',
+            'region' => 'nullable|string|max:64',
             'bucket_name' => 'required|string|max:255',
             'use_path_style_endpoint' => 'boolean',
             'enabled' => 'boolean',
@@ -22,6 +23,7 @@ class NewS3FormRequest extends AdminFormRequest
     {
         $validated = parent::validated($key, $default);
 
+        $validated['region'] = trim((string) ($validated['region'] ?? '')) ?: 'us-east-1';
         $validated['use_path_style_endpoint'] = (bool) ($validated['use_path_style_endpoint'] ?? false);
         $validated['enabled'] = (bool) ($validated['enabled'] ?? true);
 

--- a/app/Http/Requests/Admin/S3FormRequest.php
+++ b/app/Http/Requests/Admin/S3FormRequest.php
@@ -12,6 +12,7 @@ class S3FormRequest extends AdminFormRequest
             'access_key' => 'required|string|max:255',
             'secret_key' => 'required|string|max:255',
             'endpoint' => 'nullable|url|max:255',
+            'region' => 'nullable|string|max:64',
             'bucket_name' => 'required|string|max:255',
             'use_path_style_endpoint' => 'boolean',
             'enabled' => 'boolean',
@@ -22,6 +23,7 @@ class S3FormRequest extends AdminFormRequest
     {
         $validated = parent::validated($key, $default);
 
+        $validated['region'] = trim((string) ($validated['region'] ?? '')) ?: 'us-east-1';
         $validated['use_path_style_endpoint'] = (bool) ($validated['use_path_style_endpoint'] ?? false);
         $validated['enabled'] = (bool) ($validated['enabled'] ?? true);
 

--- a/app/Models/S3.php
+++ b/app/Models/S3.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $access_key
  * @property string $secret_key
  * @property string|null $endpoint
+ * @property string $region
  * @property string $bucket_name
  * @property bool $use_path_style_endpoint
  * @property bool $enabled
@@ -50,6 +51,7 @@ class S3 extends Model
         'access_key',
         'secret_key',
         'endpoint',
+        'region',
         'bucket_name',
         'use_path_style_endpoint',
         'enabled',
@@ -61,6 +63,7 @@ class S3 extends Model
         'access_key' => 'required|string|max:255',
         'secret_key' => 'required|string|max:255',
         'endpoint' => 'nullable|url|max:255',
+        'region' => 'nullable|string|max:64',
         'bucket_name' => 'required|string|max:255',
         'use_path_style_endpoint' => 'boolean',
         'enabled' => 'boolean',
@@ -96,7 +99,7 @@ class S3 extends Model
             'key' => $this->access_key,
             'secret' => $this->secret_key,
             'bucket' => $this->bucket_name,
-            'region' => 'us-east-1',
+            'region' => $this->region ?: 'us-east-1',
             'endpoint' => $this->endpoint,
             'use_path_style_endpoint' => $this->use_path_style_endpoint,
         ];
@@ -111,7 +114,7 @@ class S3 extends Model
             'key' => $this->access_key,
             'secret' => $this->secret_key,
             'bucket' => $this->bucket_name,
-            'region' => 'us-east-1',
+            'region' => $this->region ?: 'us-east-1',
             'endpoint' => $this->endpoint,
             'force_path_style' => $this->use_path_style_endpoint,
             'prefix' => env('RUSTIC_S3_PREFIX', 'rustic-repos/'),

--- a/app/Providers/BackupsServiceProvider.php
+++ b/app/Providers/BackupsServiceProvider.php
@@ -34,7 +34,7 @@ class BackupsServiceProvider extends ServiceProvider
                 'key' => $s3Bucket->access_key,
                 'secret' => $s3Bucket->secret_key,
                 'bucket' => $s3Bucket->bucket_name,
-                'region' => 'us-east-1',
+                'region' => $s3Bucket->region ?: 'us-east-1',
                 'endpoint' => $s3Bucket->endpoint,
                 'use_path_style_endpoint' => $s3Bucket->use_path_style_endpoint,
             ];
@@ -51,7 +51,7 @@ class BackupsServiceProvider extends ServiceProvider
                     'key' => $s3Bucket->access_key,
                     'secret' => $s3Bucket->secret_key,
                     'bucket' => $s3Bucket->bucket_name,
-                    'region' => 'us-east-1',
+                    'region' => $s3Bucket->region ?: 'us-east-1',
                     'endpoint' => $s3Bucket->endpoint,
                     'force_path_style' => $s3Bucket->use_path_style_endpoint,
                     'prefix' => env('RUSTIC_S3_PREFIX', 'rustic-repos/'),

--- a/database/migrations/2026_07_11_000000_add_region_to_s3_table.php
+++ b/database/migrations/2026_07_11_000000_add_region_to_s3_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s3', function (Blueprint $table) {
+            $table->string('region', 64)->default('us-east-1')->after('endpoint');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s3', function (Blueprint $table) {
+            $table->dropColumn('region');
+        });
+    }
+};

--- a/resources/views/admin/s3/new.blade.php
+++ b/resources/views/admin/s3/new.blade.php
@@ -41,6 +41,11 @@
                             <input type="text" class="form-control" id="endpoint" name="endpoint" value="{{ old('endpoint') }}" placeholder="https://s3.amazonaws.com">
                             <p class="small text-muted no-margin">The S3 endpoint URL. Leave blank for AWS S3.</p>
                         </div>
+                        <div class="form-group">
+                            <label for="region">Region</label>
+                            <input type="text" class="form-control" id="region" name="region" value="{{ old('region', 'us-east-1') }}" placeholder="us-east-1">
+                            <p class="small text-muted no-margin">Required for some S3-compatible providers such as Backblaze B2, which uses regions like <code>us-west-004</code>.</p>
+                        </div>
                     </div>
 
                     <div class="col-md-6">
@@ -112,15 +117,17 @@
             access_key: $('#access_key').val(),
             secret_key: $('#secret_key').val(),
             endpoint: $('#endpoint').val(),
+            region: $('#region').val(),
             bucket_name: $('#bucket_name').val(),
-            use_path_style_endpoint: $('input[name="use_path_style_endpoint"]').is(':checked') ? '1' : '0',
+            use_path_style_endpoint: $('#use_path_style_endpoint').is(':checked') ? '1' : '0',
         })
         .done(function (response) {
             swal({ type: 'success', title: 'Success', text: response.message });
         })
         .fail(function (xhr) {
             const response = xhr.responseJSON || {};
-            swal({ type: 'error', title: 'Connection Failed', text: response.message || 'An unexpected error occurred.' });
+            const message = response.message || xhr.responseText || `Request failed with status ${xhr.status}.`;
+            swal({ type: 'error', title: 'Connection Failed', text: message });
         })
         .always(function () {
             $button.prop('disabled', false);

--- a/resources/views/admin/s3/view/details.blade.php
+++ b/resources/views/admin/s3/view/details.blade.php
@@ -47,7 +47,12 @@
                     <div class="form-group">
                         <label for="endpoint" class="control-label">Endpoint</label>
                         <input type="url" name="endpoint" value="{{ old('endpoint', $s3->endpoint) }}" class="form-control" />
-                        <p class="text-muted small">The endpoint URL for the S3 service. Leave empty for AWS S3.</p>
+                        <p class="text-muted small">The endpoint URL for the S3 service, make sure to include <code>https://</code>. Leave empty for AWS S3.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="region" class="control-label">Region</label>
+                        <input type="text" name="region" value="{{ old('region', $s3->region ?: 'us-east-1') }}" class="form-control" />
+                        <p class="text-muted small">The region for the S3 service. For example, <code>us-west-004</code> on BackBlaze. Leave blank for us-east-1 on AWS</p>
                     </div>
                     <div class="form-group">
                         <label for="bucket_name" class="control-label">Bucket Name <span class="field-required"></span></label>
@@ -99,15 +104,17 @@
             access_key: $('input[name="access_key"]').val(),
             secret_key: $('input[name="secret_key"]').val(),
             endpoint: $('input[name="endpoint"]').val(),
+            region: $('input[name="region"]').val(),
             bucket_name: $('input[name="bucket_name"]').val(),
-            use_path_style_endpoint: $('input[name="use_path_style_endpoint"]').is(':checked') ? '1' : '0',
+            use_path_style_endpoint: $('#use_path_style_endpoint').is(':checked') ? '1' : '0',
         })
         .done(function (response) {
             swal({ type: 'success', title: 'Success', text: response.message });
         })
         .fail(function (xhr) {
             const response = xhr.responseJSON || {};
-            swal({ type: 'error', title: 'Connection Failed', text: response.message || 'An unexpected error occurred.' });
+            const message = response.message || xhr.responseText || `Request failed with status ${xhr.status}.`;
+            swal({ type: 'error', title: 'Connection Failed', text: message });
         })
         .always(function () {
             $button.prop('disabled', false);

--- a/resources/views/admin/s3/view/index.blade.php
+++ b/resources/views/admin/s3/view/index.blade.php
@@ -50,6 +50,7 @@
                             @endif
                         </td>
                     </tr>
+                    <tr><td>Region</td><td><code>{{ $s3->region ?: 'us-east-1' }}</code></td></tr>
                     <tr>
                         <td>Path Style Endpoints</td>
                         <td>
@@ -102,11 +103,7 @@
                         <h3>{{ humanizeSize($storageUsed) }}</h3>
                         <p>Estimated Storage Usage</p>
                     </div>
-<<<<<<< HEAD
-                    <div class="icon"><i class="fa bi-bucket-fill"></i></div>
-=======
                     <div class="icon"><i class="fa fa-cloud"></i></div>
->>>>>>> main
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Because the region value is hardcoded, it isn't possible to use S3 storage in other regions or providers. This fix allows the user to specify a region when creating or editing an S3 Storage Bucket.