### PR TITLE
minor ui tweaks in admin dash & account settings

### DIFF
--- a/resources/lang/en/strings.php
+++ b/resources/lang/en/strings.php
@@ -36,7 +36,7 @@ return [
     'created' => 'Created',
     'expires' => 'Expires',
     'public_key' => 'Token',
-    'api_access' => 'Api Access',
+    'api_access' => 'API Access',
     'never' => 'never',
     'sign_out' => 'Sign out',
     'admin_control' => 'Admin Control',

--- a/resources/scripts/components/dashboard/AccountApiContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountApiContainer.tsx
@@ -82,10 +82,10 @@ const AccountApiContainer = () => {
     };
 
     return (
-        <PageContentBlock title={'Api Key'}>
+        <PageContentBlock title={'API Key'}>
             <FlashMessageRender byKey='account:api-keys' />
             <ApiKeyModal visible={apiKey.length > 0} onModalDismissed={() => setApiKey('')} apiKey={apiKey} />
-            <ServerHeader title='Api Keys' />
+            <ServerHeader title='API Keys' />
 
             <CreateApiKeyModal
                 open={showCreateModal}

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -69,10 +69,10 @@
               <h4 class="list-group-item-heading"><i class="fa fa-fw fa-comments"></i> Discord</h4>
               <p class="list-group-item-text">Join the community, ask questions, and stay up to date.</p>
             </a>
-            <div class="list-group-item support-item">
+            <a href="https://github.com/BlueprintFramework/hydrodactyl" target="_blank" rel="noopener" class="list-group-item support-item">
               <h4 class="list-group-item-heading"><i class="fa fa-fw fa-star"></i> Share</h4>
               <p class="list-group-item-text">Star the repo on GitHub and share it with someone who might find it useful!</p>
-            </div>
+            </a>
           </div>
         </div>
         <div class="modal-footer">

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -215,7 +215,7 @@
         {{ $appVersion }}<br />
         <strong><i class="fa fa-fw fa-clock-o"></i></strong> {{ round(microtime(true) - LARAVEL_START, 3) }}s
       </div>
-      Copyright &copy; 2015 - {{ date('Y') }} <a href="https://hydrodactyl.dev">BlueprintFramework</a> and <a
+      Copyright &copy; 2015 - {{ date('Y') }} <a href="https://blueprint.zip/">BlueprintFramework</a> and <a
         href="https://hydrodactyl.dev">Hydrodactyl</a>.
     </footer>
   </div>


### PR DESCRIPTION
> fixes blueprint's link in the admin dashboard being hydrodactyl instead of blueprint
> adds a clickable link to the hydrodactyl github repo in the support the project modal

> capitalize API in the client dashboard and other places to be consistent with other capitalization in the app