### PR TITLE
feat(captcha): add Cap (trycap.dev) as a captcha provider

### DIFF
--- a/app/Enums/Captcha/Captchas.php
+++ b/app/Enums/Captcha/Captchas.php
@@ -8,12 +8,14 @@ enum Captchas: string
     case TURNSTILE = 'turnstile';
     case HCAPTCHA = 'hcaptcha';
     case RECAPTCHA = 'recaptcha';
+    case CAP = 'cap';
 
     private const DESCRIPTION_MAP = [
         self::NONE->value => 'Disabled',
         self::TURNSTILE->value => 'Cloudflare Turnstile',
         self::HCAPTCHA->value => 'HCaptcha',
         self::RECAPTCHA->value => 'Google ReCaptcha',
+        self::CAP->value => 'Cap',
     ];
 
 

--- a/app/Http/Requests/Admin/Settings/CaptchaSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Settings/CaptchaSettingsFormRequest.php
@@ -10,7 +10,7 @@ class CaptchaSettingsFormRequest extends AdminFormRequest
     public function rules(): array
     {
         return [
-            'pterodactyl:captcha:provider' => ['required', 'string', Rule::in(['none', 'turnstile', 'hcaptcha', 'recaptcha'])],
+            'pterodactyl:captcha:provider' => ['required', 'string', Rule::in(['none', 'turnstile', 'hcaptcha', 'recaptcha', 'cap'])],
             'pterodactyl:captcha:turnstile:site_key' => [
                 'nullable',
                 'string',
@@ -47,6 +47,25 @@ class CaptchaSettingsFormRequest extends AdminFormRequest
                 'max:255',
                 'required_if:pterodactyl:captcha:provider,recaptcha',
             ],
+            'pterodactyl:captcha:cap:site_key' => [
+                'nullable',
+                'string',
+                'max:255',
+                'required_if:pterodactyl:captcha:provider,cap',
+            ],
+            'pterodactyl:captcha:cap:secret_key' => [
+                'nullable',
+                'string',
+                'max:255',
+                'required_if:pterodactyl:captcha:provider,cap',
+            ],
+            'pterodactyl:captcha:cap:server_url' => [
+                'nullable',
+                'string',
+                'max:255',
+                'url',
+                'required_if:pterodactyl:captcha:provider,cap',
+            ],
         ];
     }
 
@@ -60,6 +79,9 @@ class CaptchaSettingsFormRequest extends AdminFormRequest
             'pterodactyl:captcha:hcaptcha:secret_key' => 'hCaptcha Secret Key',
             'pterodactyl:captcha:recaptcha:site_key' => 'reCAPTCHA Site Key',
             'pterodactyl:captcha:recaptcha:secret_key' => 'reCAPTCHA Secret Key',
+            'pterodactyl:captcha:cap:site_key' => 'Cap Site Key',
+            'pterodactyl:captcha:cap:secret_key' => 'Cap Secret Key',
+            'pterodactyl:captcha:cap:server_url' => 'Cap Server URL',
         ];
     }
 
@@ -75,6 +97,9 @@ class CaptchaSettingsFormRequest extends AdminFormRequest
             $data['pterodactyl:captcha:hcaptcha:secret_key'] = '';
             $data['pterodactyl:captcha:recaptcha:site_key'] = '';
             $data['pterodactyl:captcha:recaptcha:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:site_key'] = '';
+            $data['pterodactyl:captcha:cap:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:server_url'] = '';
         }
 
         // Clear other provider settings when switching providers
@@ -83,16 +108,32 @@ class CaptchaSettingsFormRequest extends AdminFormRequest
             $data['pterodactyl:captcha:hcaptcha:secret_key'] = '';
             $data['pterodactyl:captcha:recaptcha:site_key'] = '';
             $data['pterodactyl:captcha:recaptcha:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:site_key'] = '';
+            $data['pterodactyl:captcha:cap:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:server_url'] = '';
         } elseif ($data['pterodactyl:captcha:provider'] === 'hcaptcha') {
             $data['pterodactyl:captcha:turnstile:site_key'] = '';
             $data['pterodactyl:captcha:turnstile:secret_key'] = '';
             $data['pterodactyl:captcha:recaptcha:site_key'] = '';
             $data['pterodactyl:captcha:recaptcha:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:site_key'] = '';
+            $data['pterodactyl:captcha:cap:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:server_url'] = '';
         } elseif ($data['pterodactyl:captcha:provider'] === 'recaptcha') {
             $data['pterodactyl:captcha:turnstile:site_key'] = '';
             $data['pterodactyl:captcha:turnstile:secret_key'] = '';
             $data['pterodactyl:captcha:hcaptcha:site_key'] = '';
             $data['pterodactyl:captcha:hcaptcha:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:site_key'] = '';
+            $data['pterodactyl:captcha:cap:secret_key'] = '';
+            $data['pterodactyl:captcha:cap:server_url'] = '';
+        } elseif ($data['pterodactyl:captcha:provider'] === 'cap') {
+            $data['pterodactyl:captcha:turnstile:site_key'] = '';
+            $data['pterodactyl:captcha:turnstile:secret_key'] = '';
+            $data['pterodactyl:captcha:hcaptcha:site_key'] = '';
+            $data['pterodactyl:captcha:hcaptcha:secret_key'] = '';
+            $data['pterodactyl:captcha:recaptcha:site_key'] = '';
+            $data['pterodactyl:captcha:recaptcha:secret_key'] = '';
         }
 
         // Apply the $only filter if provided, similar to parent class

--- a/app/Http/ViewComposers/AssetComposer.php
+++ b/app/Http/ViewComposers/AssetComposer.php
@@ -43,9 +43,35 @@ class AssetComposer
         'enabled' => $this->captcha->getDefaultDriver() !== 'none',
         'provider' => $this->captcha->getDefaultDriver(),
         'siteKey' => $this->getSiteKeyForCurrentProvider(),
+        'serverUrl' => $this->getServerUrlForCurrentProvider(),
         'scriptIncludes' => $this->captcha->getScriptIncludes(),
       ],
     ]);
+  }
+
+  /**
+   * Get the server URL for the currently active captcha provider.
+   *
+   * Only Cap needs a server URL; other providers return an empty string.
+   */
+  private function getServerUrlForCurrentProvider(): string
+  {
+    $provider = $this->captcha->getDefaultDriver();
+
+    if ($provider === 'none') {
+      return '';
+    }
+
+    try {
+      $driver = $this->captcha->driver();
+      if (method_exists($driver, 'getServerUrl')) {
+        return $driver->getServerUrl();
+      }
+    } catch (\Exception $e) {
+      // Silently fail to avoid exposing errors to frontend
+    }
+
+    return '';
   }
 
   /**

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -38,6 +38,9 @@ class SettingsServiceProvider extends ServiceProvider
     'pterodactyl:captcha:hcaptcha:secret_key',
     'pterodactyl:captcha:recaptcha:site_key',
     'pterodactyl:captcha:recaptcha:secret_key',
+    'pterodactyl:captcha:cap:site_key',
+    'pterodactyl:captcha:cap:secret_key',
+    'pterodactyl:captcha:cap:server_url',
   ];
 
 
@@ -64,6 +67,7 @@ class SettingsServiceProvider extends ServiceProvider
     'pterodactyl:captcha:turnstile:secret_key',
     'pterodactyl:captcha:hcaptcha:secret_key',
     'pterodactyl:captcha:recaptcha:secret_key',
+    'pterodactyl:captcha:cap:secret_key',
   ];
 
   /**

--- a/app/Services/Captcha/CaptchaManager.php
+++ b/app/Services/Captcha/CaptchaManager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Manager;
 use Pterodactyl\Services\Captcha\Providers\TurnstileProvider;
 use Pterodactyl\Services\Captcha\Providers\HCaptchaProvider;
 use Pterodactyl\Services\Captcha\Providers\RecaptchaProvider;
+use Pterodactyl\Services\Captcha\Providers\CapProvider;
 use Pterodactyl\Services\Captcha\Providers\NullProvider;
 use Pterodactyl\Contracts\Repository\SettingsRepositoryInterface;
 
@@ -66,6 +67,18 @@ class CaptchaManager extends Manager
         return new RecaptchaProvider([
             'site_key' => config('pterodactyl.captcha.recaptcha.site_key', ''),
             'secret_key' => config('pterodactyl.captcha.recaptcha.secret_key', ''),
+        ]);
+    }
+
+    /**
+     * Create the Cap captcha driver.
+     */
+    public function createCapDriver(): CapProvider
+    {
+        return new CapProvider([
+            'site_key' => config('pterodactyl.captcha.cap.site_key', ''),
+            'secret_key' => config('pterodactyl.captcha.cap.secret_key', ''),
+            'server_url' => config('pterodactyl.captcha.cap.server_url', ''),
         ]);
     }
 

--- a/app/Services/Captcha/Providers/CapProvider.php
+++ b/app/Services/Captcha/Providers/CapProvider.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Pterodactyl\Services\Captcha\Providers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Pterodactyl\Contracts\Captcha\CaptchaProviderInterface;
+
+class CapProvider implements CaptchaProviderInterface
+{
+    protected string $siteKey;
+    protected string $secretKey;
+    protected string $serverUrl;
+
+    public function __construct(array $config)
+    {
+        $this->siteKey = $config['site_key'] ?? '';
+        $this->secretKey = $config['secret_key'] ?? '';
+        $this->serverUrl = rtrim($config['server_url'] ?? '', '/');
+    }
+
+    /**
+     * Get the HTML widget for the captcha.
+     */
+    public function getWidget(string $form): string
+    {
+        if (empty($this->siteKey) || empty($this->serverUrl)) {
+            return '';
+        }
+
+        return sprintf(
+            '<cap-widget data-cap-api-endpoint="%s/%s/"></cap-widget>',
+            htmlspecialchars($this->serverUrl, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->siteKey, ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    /**
+     * Verify a captcha response.
+     */
+    public function verify(string $response, ?string $remoteIp = null): bool
+    {
+        if (empty($this->secretKey) || empty($this->serverUrl) || empty($response)) {
+            Log::warning('Cap verification failed: Missing secret key, server url or response', [
+                'secret_key_empty' => empty($this->secretKey),
+                'server_url_empty' => empty($this->serverUrl),
+                'response_empty' => empty($response),
+            ]);
+            return false;
+        }
+
+        try {
+            $httpResponse = Http::timeout(10)
+                ->asJson()
+                ->post($this->serverUrl . '/siteverify', [
+                    'secret' => $this->secretKey,
+                    'response' => $response,
+                ]);
+
+            if (!$httpResponse->successful()) {
+                Log::warning('Cap verification failed: HTTP ' . $httpResponse->status(), [
+                    'response_body' => $httpResponse->body(),
+                ]);
+                return false;
+            }
+
+            $result = $httpResponse->json();
+
+            if (!isset($result['success'])) {
+                Log::warning('Cap verification failed: Invalid response format', [
+                    'result' => $result,
+                ]);
+                return false;
+            }
+
+            if (!$result['success'] && isset($result['errors'])) {
+                Log::warning('Cap verification failed', [
+                    'errors' => $result['errors'],
+                    'full_result' => $result,
+                ]);
+            }
+
+            return (bool) $result['success'];
+        } catch (\Exception $e) {
+            Log::error('Cap verification exception', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            return false;
+        }
+    }
+
+    /**
+     * Get the JavaScript includes needed for this captcha provider.
+     */
+    public function getScriptIncludes(): array
+    {
+        return [
+            'https://cdn.jsdelivr.net/npm/@cap.js/widget',
+        ];
+    }
+
+    /**
+     * Get the provider name.
+     */
+    public function getName(): string
+    {
+        return 'cap';
+    }
+
+    /**
+     * Get the site key for frontend use.
+     */
+    public function getSiteKey(): string
+    {
+        return $this->siteKey;
+    }
+
+    /**
+     * Get the Cap server URL for frontend use.
+     */
+    public function getServerUrl(): string
+    {
+        return $this->serverUrl;
+    }
+
+    /**
+     * Check if the provider is properly configured.
+     */
+    public function isConfigured(): bool
+    {
+        return !empty($this->siteKey) && !empty($this->secretKey) && !empty($this->serverUrl);
+    }
+
+    /**
+     * Get the response field name for this provider.
+     */
+    public function getResponseFieldName(): string
+    {
+        return 'cap-token';
+    }
+}

--- a/config/pterodactyl.php
+++ b/config/pterodactyl.php
@@ -66,6 +66,11 @@ return [
             'site_key' => env('RECAPTCHA_SITE_KEY', ''),
             'secret_key' => env('RECAPTCHA_SECRET_KEY', ''),
         ],
+        'cap' => [
+            'site_key' => env('CAP_SITE_KEY', ''),
+            'secret_key' => env('CAP_SECRET_KEY', ''),
+            'server_url' => env('CAP_SERVER_URL', 'https://cap.example.com'),
+        ],
         'forms' => [
             'login' => env('CAPTCHA_LOGIN', false),
             'forgot_password' => env('CAPTCHA_FORGOT_PASSWORD', false),

--- a/resources/scripts/lib/captcha/CaptchaManager.ts
+++ b/resources/scripts/lib/captcha/CaptchaManager.ts
@@ -14,6 +14,7 @@ export class CaptchaManager {
             enabled: false,
             provider: 'none',
             siteKey: '',
+            serverUrl: '',
             scriptIncludes: [],
         };
 
@@ -93,6 +94,7 @@ export class CaptchaManager {
         try {
             const config: CaptchaRenderConfig = {
                 siteKey: this.config.siteKey,
+                serverUrl: this.config.serverUrl,
                 theme: 'auto',
                 size: 'normal',
                 onSuccess: (token: string) => this.handleSuccess(token),

--- a/resources/scripts/lib/captcha/CaptchaProvider.ts
+++ b/resources/scripts/lib/captcha/CaptchaProvider.ts
@@ -2,6 +2,7 @@ export interface CaptchaConfig {
     enabled: boolean;
     provider: string;
     siteKey: string;
+    serverUrl?: string;
     scriptIncludes: string[];
 }
 
@@ -54,6 +55,7 @@ export interface CaptchaProviderInterface {
 
 export interface CaptchaRenderConfig {
     siteKey: string;
+    serverUrl?: string;
     theme?: 'light' | 'dark' | 'auto';
     size?: 'normal' | 'compact' | 'invisible' | 'flexible';
     onSuccess?: (token: string) => void;

--- a/resources/scripts/lib/captcha/CaptchaProviderFactory.ts
+++ b/resources/scripts/lib/captcha/CaptchaProviderFactory.ts
@@ -1,4 +1,5 @@
 import type { CaptchaProviderInterface } from './CaptchaProvider';
+import { CapProvider } from './providers/CapProvider';
 import { HCaptchaProvider } from './providers/HCaptchaProvider';
 import { NullProvider } from './providers/NullProvider';
 import { RecaptchaProvider } from './providers/RecaptchaProvider';
@@ -8,6 +9,7 @@ const providers: Map<string, () => CaptchaProviderInterface> = new Map([
     ['turnstile', () => new TurnstileProvider()],
     ['hcaptcha', () => new HCaptchaProvider()],
     ['recaptcha', () => new RecaptchaProvider()],
+    ['cap', () => new CapProvider()],
     ['none', () => new NullProvider()],
 ]);
 

--- a/resources/scripts/lib/captcha/index.ts
+++ b/resources/scripts/lib/captcha/index.ts
@@ -11,6 +11,7 @@ export type {
 
 export { BaseCaptchaProvider } from './CaptchaProvider';
 export { CaptchaProviderFactory } from './CaptchaProviderFactory';
+export { CapProvider } from './providers/CapProvider';
 export { HCaptchaProvider } from './providers/HCaptchaProvider';
 export { NullProvider } from './providers/NullProvider';
 export { RecaptchaProvider } from './providers/RecaptchaProvider';

--- a/resources/scripts/lib/captcha/providers/CapProvider.ts
+++ b/resources/scripts/lib/captcha/providers/CapProvider.ts
@@ -1,0 +1,149 @@
+import { BaseCaptchaProvider, type CaptchaRenderConfig } from '../CaptchaProvider';
+import '../types';
+
+type CapWidgetElement = HTMLElement & {
+    tokenValue?: string;
+    reset?: () => void;
+};
+
+export class CapProvider extends BaseCaptchaProvider {
+    private static readonly SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@cap.js/widget';
+    private loadPromise: Promise<void> | null = null;
+    private widgetElements = new Map<string, CapWidgetElement>();
+    private tokenByWidget = new Map<string, string>();
+    private nextWidgetId = 1;
+
+    getName(): string {
+        return 'cap';
+    }
+
+    getScriptUrls(): string[] {
+        return [CapProvider.SCRIPT_URL];
+    }
+
+    getResponseFieldName(): string {
+        return 'cap-token';
+    }
+
+    isLoaded(): boolean {
+        return typeof customElements !== 'undefined' && customElements.get('cap-widget') !== undefined;
+    }
+
+    loadSdk(): Promise<void> {
+        if (this.loadPromise) {
+            return this.loadPromise;
+        }
+
+        if (this.isLoaded()) {
+            return Promise.resolve();
+        }
+
+        this.loadPromise = new Promise((resolve, reject) => {
+            // Check if script is already in DOM
+            const existingScript = document.querySelector(`script[src="${CapProvider.SCRIPT_URL}"]`);
+            if (existingScript) {
+                if (this.isLoaded()) {
+                    resolve();
+                    return;
+                }
+                // Wait for the existing script to define the widget
+                customElements.whenDefined('cap-widget').then(
+                    () => resolve(),
+                    () => reject(new Error('Failed to load Cap widget SDK')),
+                );
+                existingScript.addEventListener('error', () => reject(new Error('Failed to load Cap widget SDK')));
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = CapProvider.SCRIPT_URL;
+            script.async = true;
+
+            script.onload = () => {
+                // The script defines the cap-widget custom element on execution
+                customElements.whenDefined('cap-widget').then(
+                    () => resolve(),
+                    () => reject(new Error('Failed to load Cap widget SDK')),
+                );
+            };
+
+            script.onerror = () => {
+                reject(new Error('Failed to load Cap widget SDK'));
+            };
+
+            document.head.appendChild(script);
+        });
+
+        return this.loadPromise;
+    }
+
+    async render(container: HTMLElement, config: CaptchaRenderConfig): Promise<string> {
+        await this.loadSdk();
+
+        const widgetId = `cap-${this.nextWidgetId++}`;
+        const widget = document.createElement('cap-widget') as CapWidgetElement;
+        const serverUrl = (config.serverUrl || window.SiteConfiguration?.captcha?.serverUrl || '').replace(/\/+$/, '');
+
+        if (!serverUrl) {
+            throw new Error('Cap server URL is not configured');
+        }
+
+        widget.setAttribute('data-cap-api-endpoint', `${serverUrl}/${config.siteKey}/`);
+        widget.addEventListener('solve', (event) => {
+            const token = (event as CustomEvent).detail?.token || widget.tokenValue || '';
+            if (token) {
+                this.tokenByWidget.set(widgetId, token);
+                config.onSuccess?.(token);
+            }
+        });
+        widget.addEventListener('error', (event) => {
+            // 'error' on HTMLElement is typed as ErrorEvent in the DOM lib, but the
+            // cap-widget dispatches a CustomEvent here
+            const detail = (event as unknown as CustomEvent).detail;
+            config.onError?.(detail);
+        });
+        widget.addEventListener('reset', () => {
+            this.tokenByWidget.delete(widgetId);
+        });
+
+        container.appendChild(widget);
+        this.widgetElements.set(widgetId, widget);
+
+        return widgetId;
+    }
+
+    getResponse(widgetId?: string): string | null {
+        if (!widgetId) {
+            return null;
+        }
+
+        const widget = this.widgetElements.get(widgetId);
+
+        if (!widget) {
+            return null;
+        }
+
+        return this.tokenByWidget.get(widgetId) || widget.tokenValue || null;
+    }
+
+    reset(widgetId?: string): void {
+        if (!widgetId) {
+            return;
+        }
+
+        const widget = this.widgetElements.get(widgetId);
+        widget?.reset?.();
+        this.tokenByWidget.delete(widgetId);
+    }
+
+    remove(widgetId?: string): void {
+        if (!widgetId) {
+            return;
+        }
+
+        const widget = this.widgetElements.get(widgetId);
+        widget?.remove();
+        this.widgetElements.delete(widgetId);
+        this.tokenByWidget.delete(widgetId);
+    }
+}

--- a/resources/scripts/lib/captcha/types.ts
+++ b/resources/scripts/lib/captcha/types.ts
@@ -10,6 +10,7 @@ declare global {
                 enabled: boolean;
                 provider: string;
                 siteKey: string;
+                serverUrl?: string;
                 scriptIncludes: string[];
             };
         };

--- a/resources/views/admin/settings/captcha.blade.php
+++ b/resources/views/admin/settings/captcha.blade.php
@@ -161,6 +161,54 @@
         </div>
 
 
+        <div class="box" id="cap-settings" style="display: none;">
+          <div class="box-header with-border">
+            <h3 class="box-title">Cap Configuration</h3>
+          </div>
+          <div class="box-body">
+            <div class="row">
+              <div class="form-group col-md-4">
+                <label class="control-label">Server URL</label>
+                <div>
+                  <input type="text" class="form-control" name="pterodactyl:captcha:cap:server_url"
+                    value="{{ old('pterodactyl:captcha:cap:server_url', config('pterodactyl.captcha.cap.server_url', '')) }}" />
+                  <p class="text-muted"><small>The base URL of your Cap instance, e.g. https://cap.example.com. This is used for server-side verification.</small></p>
+                </div>
+              </div>
+              <div class="form-group col-md-4">
+                <label class="control-label">Site Key</label>
+                <div>
+                  <input type="text" class="form-control" name="pterodactyl:captcha:cap:site_key"
+                    value="{{ old('pterodactyl:captcha:cap:site_key', config('pterodactyl.captcha.cap.site_key', '')) }}" />
+                  <p class="text-muted"><small>The site key provided by Cap. This is used in the frontend widget.</small></p>
+                </div>
+              </div>
+              <div class="form-group col-md-4">
+                <label class="control-label">Secret Key</label>
+                <div>
+                  <input type="password" class="form-control" name="pterodactyl:captcha:cap:secret_key"
+                    value="{{ old('pterodactyl:captcha:cap:secret_key', config('pterodactyl.captcha.cap.secret_key', '')) }}" />
+                  <p class="text-muted"><small>The secret key provided by Cap. This is used for server-side verification.</small></p>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <div class="alert alert-info">
+                  <strong>Setup Instructions:</strong>
+                  <ol>
+                    <li>Set up a Cap server or use the hosted one — see the <a href="https://trycap.dev" target="_blank">Cap website</a> and <a href="https://docs.cap.js.org" target="_blank">Cap documentation</a></li>
+                    <li>Create a new site in your Cap instance</li>
+                    <li>Add your panel domain to the site configuration</li>
+                    <li>Copy the Site Key and Secret Key from the dashboard</li>
+                    <li>Enter your Cap instance base URL, then paste the keys into the fields above</li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="box box-primary">
           <div class="box-footer">
             {{ csrf_field() }}
@@ -177,6 +225,7 @@
       const turnstileSettings = document.getElementById('turnstile-settings');
       const hcaptchaSettings = document.getElementById('hcaptcha-settings');
       const recaptchaSettings = document.getElementById('recaptcha-settings');
+      const capSettings = document.getElementById('cap-settings');
 
       function toggleSettings() {
         const provider = providerSelect.value;
@@ -185,6 +234,7 @@
         turnstileSettings.style.display = 'none';
         hcaptchaSettings.style.display = 'none';
         recaptchaSettings.style.display = 'none';
+        capSettings.style.display = 'none';
 
         if (provider === 'turnstile') {
           turnstileSettings.style.display = 'block';
@@ -192,6 +242,8 @@
           hcaptchaSettings.style.display = 'block';
         } else if (provider === 'recaptcha') {
           recaptchaSettings.style.display = 'block';
+        } else if (provider === 'cap') {
+          capSettings.style.display = 'block';
         }
       }
 

--- a/tests/Unit/Services/Captcha/Providers/CapProviderTest.php
+++ b/tests/Unit/Services/Captcha/Providers/CapProviderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Pterodactyl\Tests\Unit\Services\Captcha\Providers;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Pterodactyl\Services\Captcha\Providers\CapProvider;
+use Pterodactyl\Tests\TestCase;
+
+class CapProviderTest extends TestCase
+{
+    private const SERVER_URL = 'https://cap.example.com';
+    private const SITE_KEY = 'test-site-key';
+    private const SECRET_KEY = 'test-secret-key';
+
+    private function makeProvider(array $overrides = []): CapProvider
+    {
+        return new CapProvider(array_merge([
+            'site_key' => self::SITE_KEY,
+            'secret_key' => self::SECRET_KEY,
+            'server_url' => self::SERVER_URL,
+        ], $overrides));
+    }
+
+    /**
+     * Test that the widget HTML contains the Cap API endpoint.
+     */
+    public function testGetWidgetContainsApiEndpoint()
+    {
+        $widget = $this->provider()->getWidget('default');
+
+        $this->assertStringContainsString('<cap-widget', $widget);
+        $this->assertStringContainsString('data-cap-api-endpoint="' . self::SERVER_URL . '/' . self::SITE_KEY . '/"', $widget);
+    }
+
+    /**
+     * Test that the widget HTML is empty when the provider is not configured.
+     */
+    public function testGetWidgetReturnsEmptyStringWhenUnconfigured()
+    {
+        $this->assertSame('', $this->makeProvider(['site_key' => ''])->getWidget('default'));
+        $this->assertSame('', $this->makeProvider(['server_url' => ''])->getWidget('default'));
+    }
+
+    /**
+     * Test that the widget HTML escapes the server url and site key.
+     */
+    public function testGetWidgetEscapesValues()
+    {
+        $provider = $this->makeProvider(['site_key' => 'key"><script>']);
+        $widget = $provider->getWidget('default');
+
+        $this->assertStringNotContainsString('"><script>', $widget);
+        $this->assertStringContainsString('key&quot;&gt;&lt;script&gt;', $widget);
+    }
+
+    /**
+     * Test that verification posts the secret and response as JSON to siteverify.
+     */
+    public function testVerifyPostsSecretAndResponseToSiteverify()
+    {
+        Http::fake([
+            self::SERVER_URL . '/siteverify' => Http::response(['success' => true]),
+        ]);
+
+        $this->assertTrue($this->provider()->verify('valid-token', '127.0.0.1'));
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === self::SERVER_URL . '/siteverify'
+                && $request->method() === 'POST'
+                && str_contains($request->header('Content-Type')[0] ?? '', 'application/json')
+                && $request->data() === [
+                    'secret' => self::SECRET_KEY,
+                    'response' => 'valid-token',
+                ];
+        });
+    }
+
+    /**
+     * Test that verification returns false when the Cap server reports failure.
+     */
+    public function testVerifyReturnsFalseOnUnsuccessfulVerification()
+    {
+        Http::fake([
+            self::SERVER_URL . '/siteverify' => Http::response(['success' => false, 'errors' => ['invalid-token']]),
+        ]);
+
+        $this->assertFalse($this->provider()->verify('bad-token'));
+    }
+
+    /**
+     * Test that verification returns false when the Cap server is unreachable.
+     */
+    public function testVerifyReturnsFalseOnNetworkFailure()
+    {
+        Http::fake(function () {
+            throw new \Exception('Connection refused');
+        });
+
+        $this->assertFalse($this->provider()->verify('any-token'));
+    }
+
+    /**
+     * Test that verification returns false when the Cap server returns an HTTP error.
+     */
+    public function testVerifyReturnsFalseOnHttpError()
+    {
+        Http::fake([
+            self::SERVER_URL . '/siteverify' => Http::response(['error' => 'Internal Server Error'], 500),
+        ]);
+
+        $this->assertFalse($this->provider()->verify('any-token'));
+    }
+
+    /**
+     * Test that verification fails fast when the secret key or response is missing.
+     */
+    public function testVerifyFailsFastWhenMissingSecretOrResponse()
+    {
+        Http::fake();
+
+        $this->assertFalse($this->makeProvider(['secret_key' => ''])->verify('token'));
+        $this->assertFalse($this->makeProvider(['server_url' => ''])->verify('token'));
+        $this->assertFalse($this->provider()->verify(''));
+
+        Http::assertNothingSent();
+    }
+
+    /**
+     * Test that verification fails fast when the server url is missing.
+     */
+    public function testVerifyFailsFastWhenMissingServerUrl()
+    {
+        Http::fake();
+
+        $this->assertFalse($this->makeProvider(['server_url' => ''])->verify('token'));
+
+        Http::assertNothingSent();
+    }
+
+    /**
+     * Test the provider metadata.
+     */
+    public function testProviderMetadata()
+    {
+        $provider = $this->provider();
+
+        $this->assertSame('cap', $provider->getName());
+        $this->assertSame('cap-token', $provider->getResponseFieldName());
+        $this->assertSame(self::SITE_KEY, $provider->getSiteKey());
+        $this->assertSame(self::SERVER_URL, $provider->getServerUrl());
+        $this->assertSame(['https://cdn.jsdelivr.net/npm/@cap.js/widget'], $provider->getScriptIncludes());
+        $this->assertTrue($provider->isConfigured());
+    }
+
+    /**
+     * Test that the server url has trailing slashes trimmed.
+     */
+    public function testServerUrlTrailingSlashIsTrimmed()
+    {
+        $provider = $this->makeProvider(['server_url' => self::SERVER_URL . '/']);
+
+        $this->assertSame(self::SERVER_URL, $provider->getServerUrl());
+    }
+
+    /**
+     * Test that the provider is not considered configured with missing values.
+     */
+    public function testIsConfiguredReturnsFalseWhenMissingValues()
+    {
+        $this->assertFalse($this->makeProvider(['site_key' => ''])->isConfigured());
+        $this->assertFalse($this->makeProvider(['secret_key' => ''])->isConfigured());
+        $this->assertFalse($this->makeProvider(['server_url' => ''])->isConfigured());
+    }
+
+    private function provider(): CapProvider
+    {
+        return $this->makeProvider();
+    }
+}


### PR DESCRIPTION
Adds the ability to use your own self-hosted Cap Captcha instance.

- Backend: CapProvider (JSON POST to {server}/siteverify), Captchas enum case, config block, CaptchaManager driver, admin form validation and provider-switch clearing, encrypted secret key, admin settings UI
- Frontend: CapProvider wrapping the cap-widget web component (solve/error/reset events), registered in CaptchaProviderFactory; serverUrl threaded through SiteConfiguration for Cap
- Tests: CapProviderTest covering verify, widget HTML, config checks and network-failure handling